### PR TITLE
Add basic shell features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
-# -sh
-# -sh
-# -sh
-# -sh
+# D-based Lisp/Haskell Interpreter Prototype
+
+This repository contains a minimal prototype for a Lisp-style interpreter written in [D](https://dlang.org/). The project is inspired by [Axel](https://github.com/axellang/axel), which translates a Lisp dialect to Haskell. In this repository we show how D can be used to build similar tooling that targets an environment with limited system commands such as those described in the [`internetcomputer`](https://github.com/Jonathan-R-Anderson/internetcomputer) project.
+
+The implementation is intentionally small and demonstrates how one might begin to build a cross compiler or interpreter that uses the D toolchain. The code is located in `src/interpreter.d`.
+
+## Building
+
+A D compiler such as `dmd` or `ldc2` is required. To cross compile for a specific target, supply the desired architecture flags to the compiler. For example:
+
+```bash
+ldc2 -mtriple=<target> src/interpreter.d -of=interpreter
+```
+
+Replace `<target>` with the appropriate triple for the operating system described in the `internetcomputer` repository.
+
+## Usage
+
+```
+./interpreter "+ 1 2"  # prints 3
+```
+
+The interpreter currently supports a very small subset of commands:
+
+- `echo` – prints its arguments
+- basic arithmetic with `+` and `-`
+- Haskell-style `for` loops, e.g. `for 1..3 echo hi`
+- concurrent commands using `&`, e.g. `echo one & echo two`
+
+These features demonstrate how additional Bash commands could be layered on top of a Haskell-inspired syntax. The goal is to eventually cover the full Bash command set, including job control and other special operators.
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -1,0 +1,71 @@
+import std.stdio;
+import std.string;
+import std.array;
+import std.algorithm;
+import std.parallelism;
+import std.range;
+
+/**
+ * Simple interpreter skeleton for a Lisp-like language.
+ * This implementation is intentionally minimal and is
+ * provided as an example of building language tooling
+ * with the D cross-compiler.
+ */
+
+void runCommand(string cmd);
+
+void run(string input) {
+    auto cmds = input.split("&");
+    if(cmds.length > 1) {
+        foreach(c; cmds) {
+            taskPool.put(() { runCommand(c.strip); });
+        }
+        taskPool.finish();
+    } else {
+        runCommand(input.strip);
+    }
+}
+
+void runCommand(string cmd) {
+    auto tokens = cmd.split();
+    if(tokens.length == 0) return;
+    auto op = tokens[0];
+    if(op == "echo") {
+        writeln(tokens[1 .. $].join(" "));
+    } else if(op == "+" || op == "-") {
+        if(tokens.length < 3) {
+            writeln("Invalid arithmetic expression");
+            return;
+        }
+        int a = to!int(tokens[1]);
+        int b = to!int(tokens[2]);
+        auto result = (op == "+") ? a + b : a - b;
+        writeln(result);
+    } else if(op == "for") {
+        if(tokens.length < 3) {
+            writeln("Usage: for start..end command");
+            return;
+        }
+        auto rangeParts = tokens[1].split("..");
+        if(rangeParts.length != 2) {
+            writeln("Invalid range");
+            return;
+        }
+        int start = to!int(rangeParts[0]);
+        int finish = to!int(rangeParts[1]);
+        string sub = tokens[2 .. $].join(" ");
+        foreach(i; iota(start, finish + 1)) {
+            runCommand(sub);
+        }
+    } else {
+        writeln("Unknown command: ", op);
+    }
+}
+
+void main(string[] args) {
+    if(args.length < 2) {
+        writeln("Usage: interpreter \"command string\"");
+        return;
+    }
+    run(args[1]);
+}


### PR DESCRIPTION
## Summary
- expand README with current command set and concurrency notes
- add a basic interpreter loop supporting `echo`, arithmetic, Haskell-style `for`, and `&` concurrency

## Testing
- `dmd src/interpreter.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0df4a68483278682132015614b57