### PR TITLE
Add interactive shell with customizable prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,9 @@ The interpreter now supports a broader set of commands:
 - concurrent commands using `&`, e.g. `echo one & echo two`
 - sequential commands separated by `;`
 
+Running the interpreter with no command argument starts an interactive shell.
+You can customize the prompt text using the `PS1` environment variable and its
+color with `PS_COLOR` (e.g. `PS_COLOR=green`). Type `exit` to leave the shell.
+
 These examples demonstrate how additional Bash commands can be layered on top of a Haskell-inspired syntax. The goal remains to eventually cover the full Bash command set, including job control and other special operators.
 

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -5,9 +5,19 @@ import std.algorithm;
 import std.parallelism;
 import std.range;
 import std.file : chdir, getcwd, dirEntries, SpanMode;
-import std.process : system;
+import std.process : system, environment;
 
 string[string] variables;
+string[string] colorCodes = [
+    "black": "\033[30m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "magenta": "\033[35m",
+    "cyan": "\033[36m",
+    "white": "\033[37m"
+];
 
 /**
  * Simple interpreter skeleton for a Lisp-like language.
@@ -117,9 +127,26 @@ void runCommand(string cmd) {
     }
 }
 
+void repl() {
+    auto ps1 = environment.get("PS1", "sh> ");
+    auto colorName = environment.get("PS_COLOR", "");
+    string colorCode;
+    if(auto c = colorName in colorCodes) colorCode = *c;
+    auto reset = colorCode.length ? "\033[0m" : "";
+    for(;;) {
+        write(colorCode, ps1, reset);
+        auto line = readln();
+        if(line is null) break;
+        line = line.strip;
+        if(line == "exit") break;
+        if(line.length == 0) continue;
+        run(line);
+    }
+}
+
 void main(string[] args) {
     if(args.length < 2) {
-        writeln("Usage: interpreter \"command string\"");
+        repl();
         return;
     }
     run(args[1]);


### PR DESCRIPTION
## Summary
- extend interpreter with a REPL mode
- allow prompt customization via `PS1` and color via `PS_COLOR`
- document interactive shell usage

## Testing
- `dmd --version` *(fails: command not found)*
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e10f64b9c83279ac1767835a8e92a