### PR TITLE
Add pseudo language framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,20 @@ The interpreter now supports a broader set of commands:
 - sequential commands separated by `;`
 
 Running the interpreter with no command argument starts an interactive shell.
-You can customize the prompt text using the `PS1` environment variable and its
-color with `PS_COLOR` (e.g. `PS_COLOR=green`). Type `exit` to leave the shell.
+You can customize the prompt text using the `PS1` environment variable and its color with `PS_COLOR` (e.g. `PS_COLOR=green`). Type `exit` to leave the shell.
 
 These examples demonstrate how additional Bash commands can be layered on top of a Haskell-inspired syntax. The goal remains to eventually cover the full Bash command set, including job control and other special operators.
 
+## Building Pseudo Languages
+
+A small lexer and parser framework inspired by Python's SLY is provided in
+`src/dlexer.d` and `src/dparser.d`. These modules allow custom token rules and
+implement a simple recursive-descent parser.
+
+The sample program `src/example.d` evaluates arithmetic expressions using this
+framework:
+
+```bash
+ldc2 src/example.d src/dlexer.d src/dparser.d -of=example
+./example "1 + 2 * 3"   # prints 7
+```

--- a/src/dlexer.d
+++ b/src/dlexer.d
@@ -1,0 +1,50 @@
+module dlexer;
+
+import std.regex : regex, match, Captures;
+import std.array : array;
+import std.string : strip;
+
+/// Represents a lexical token with type and value.
+struct Token {
+    string type;
+    string value;
+}
+
+/// Defines a single tokenization rule.
+struct Rule {
+    string name;
+    Regex!char pattern;
+}
+
+/// Simple regex-based lexer inspired by Python's SLY.
+class Lexer {
+    private Rule[] rules;
+
+    this(Rule[] rules) {
+        this.rules = rules;
+    }
+
+    /// Tokenize the given input string.
+    Token[] tokenize(string input) {
+        Token[] tokens;
+        size_t pos = 0;
+        while (pos < input.length) {
+            bool matched = false;
+            foreach (rule; rules) {
+                auto m = match(input[pos .. $], rule.pattern);
+                if (m.hit && m.hit.length > 0 && m.pre.length == 0) {
+                    tokens ~= Token(rule.name, m.hit);
+                    pos += m.hit.length;
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                // Skip unknown characters
+                pos++;
+            }
+        }
+        return tokens;
+    }
+}
+

--- a/src/dparser.d
+++ b/src/dparser.d
@@ -1,0 +1,78 @@
+module dparser;
+
+import std.stdio;
+import std.array : array;
+import std.algorithm;
+import dlexer;
+
+alias Action = long delegate(long, long);
+
+/// Simple recursive-descent parser framework with an example
+/// arithmetic parser to demonstrate defining a pseudo language.
+class Parser {
+    Token[] tokens;
+    size_t pos;
+
+    this(Token[] toks) {
+        tokens = toks;
+        pos = 0;
+    }
+
+    bool peek(string type) {
+        return pos < tokens.length && tokens[pos].type == type;
+    }
+
+    Token consume(string type) {
+        if (!peek(type)) {
+            throw new Exception("Expected " ~ type ~ ", got " ~ (pos < tokens.length ? tokens[pos].type : "EOF"));
+        }
+        return tokens[pos++];
+    }
+
+    // Example expression grammar:
+    // expr  -> term ((PLUS|MINUS) term)*
+    // term  -> factor ((TIMES|DIVIDE) factor)*
+    // factor-> NUMBER | LPAREN expr RPAREN
+
+    long parseExpression() {
+        long value = parseTerm();
+        while (peek("PLUS") || peek("MINUS")) {
+            auto op = consume(tokens[pos].type);
+            long rhs = parseTerm();
+            final switch (op.type) {
+                case "PLUS":  value += rhs; break;
+                case "MINUS": value -= rhs; break;
+                default: break;
+            }
+        }
+        return value;
+    }
+
+    long parseTerm() {
+        long value = parseFactor();
+        while (peek("TIMES") || peek("DIVIDE")) {
+            auto op = consume(tokens[pos].type);
+            long rhs = parseFactor();
+            final switch (op.type) {
+                case "TIMES":  value *= rhs; break;
+                case "DIVIDE": value /= rhs; break;
+                default: break;
+            }
+        }
+        return value;
+    }
+
+    long parseFactor() {
+        if (peek("NUMBER")) {
+            auto t = consume("NUMBER");
+            return to!long(t.value);
+        } else if (peek("LPAREN")) {
+            consume("LPAREN");
+            long value = parseExpression();
+            consume("RPAREN");
+            return value;
+        }
+        throw new Exception("Unexpected token " ~ (pos < tokens.length ? tokens[pos].type : "EOF"));
+    }
+}
+

--- a/src/example.d
+++ b/src/example.d
@@ -1,0 +1,28 @@
+import dlexer; 
+import dparser; 
+import std.regex : regex; 
+import std.stdio;
+
+void main(string[] args) {
+    if (args.length < 2) {
+        writeln("Usage: example \"1 + 2 * 3\"");
+        return;
+    }
+    auto rules = [
+        Rule("NUMBER", regex("[0-9]+")),
+        Rule("PLUS", regex("\\+")),
+        Rule("MINUS", regex("-")),
+        Rule("TIMES", regex("\\*")),
+        Rule("DIVIDE", regex("/")),
+        Rule("LPAREN", regex("\\(")),
+        Rule("RPAREN", regex("\\)")),
+        Rule("WS", regex("\\s+"))
+    ];
+    auto lex = new Lexer(rules);
+    auto tokens = lex.tokenize(args[1]);
+    // filter out whitespace tokens
+    tokens = tokens.filter!(t => t.type != "WS").array;
+    auto parser = new Parser(tokens);
+    auto result = parser.parseExpression();
+    writeln(result);
+}


### PR DESCRIPTION
## Summary
- add simple regex-based lexer
- add basic recursive-descent parser with expression example
- show how to build pseudo languages in README
- include an example program demonstrating arithmetic parsing

## Testing
- `ldc2 src/example.d src/dlexer.d src/dparser.d -of=example` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e1386df848327ad1d094f55fc8ba6