### PR TITLE
Add module loading capability to LFE REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,16 @@ lfe> (exit)
 
 The REPL exits when `(exit)` is evaluated.
 
+### Loading Modules
+
+Simple modules can be loaded with `(c "file.lfe")`. Functions defined in a
+`defmodule` form are stored using the `module:function` naming convention and can
+be invoked after the file is compiled:
+
+```lfe
+lfe> (c "tut1.lfe")
+#(module tut1)
+lfe> (tut1:double 21)
+42
+```
+


### PR DESCRIPTION
## Summary
- extend `lferepl` with helpers for tokenization and file loading
- support `(c "file")` to read a module file
- implement basic `defmodule` handling so functions are stored as `module:function`
- document new module loading feature in README

## Testing
- `ldc2 --version` *(fails: command not found)*
- `ldc2 src/lferepl.d src/dlexer.d src/dparser.d -of=lferepl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e183bf27c83278574a268ae218236