### PR TITLE
Add spawn primitive to LFE REPL

### DIFF
--- a/tut18.lfe
+++ b/tut18.lfe
@@ -1,0 +1,12 @@
+(defmodule tut18
+  (export (start 0) (say-something 2)))
+
+(defun say-something
+  ([what 0] 'done)
+  ([what times]
+   (lfe_io:format "~p~n" (list what))
+   (say-something what (- times 1))))
+
+(defun start ()
+  (spawn 'tut18 'say-something '(hello 3))
+  (spawn 'tut18 'say-something '(goodbye 3)))


### PR DESCRIPTION
## Summary
- allow the LFE REPL to spawn concurrent processes using `spawn`
- implement a helper to call functions directly
- include an example module `tut18.lfe` demonstrating the behaviour

## Testing
- `ldc2 src/lferepl.d src/dlexer.d src/dparser.d -of=lferepl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e28ecec888327a71b88e3f5df80ac