### PR TITLE
Add registered process name example in LFE

### DIFF
--- a/tut20.lfe
+++ b/tut20.lfe
@@ -1,0 +1,26 @@
+(defmodule tut20
+  (export (start 0) (ping 1) (pong 0)))
+
+(defun ping
+  ((0)
+   (! 'pong 'finished)
+   (lfe_io:format "Ping finished~n" ()))
+  ((n)
+   (! 'pong (tuple 'ping (self)))
+   (receive
+     ('pong (lfe_io:format "Ping received pong~n" ())))
+   (ping (- n 1))))
+
+(defun pong ()
+  (receive
+    ('finished
+     (lfe_io:format "Pong finished~n" ()))
+    ((tuple 'ping ping-pid)
+     (lfe_io:format "Pong received ping~n" ())
+     (! ping-pid 'pong)
+     (pong))))
+
+(defun start ()
+  (let ((pong-pid (spawn 'tut20 'pong ())))
+    (register 'pong pong-pid)
+    (spawn 'tut20 'ping '(3))))


### PR DESCRIPTION
## Summary
- add `tut20.lfe` showing how to use `register` to assign a name to a process for message passing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e2badacf08327b6077d70d2b0eb00