### PR TITLE
Add distributed LFE ping pong examples

### DIFF
--- a/tut21.lfe
+++ b/tut21.lfe
@@ -1,0 +1,27 @@
+(defmodule tut21
+  (export (start-ping 1) (start-pong 0) (ping 2) (pong 0)))
+
+(defun ping
+  ((0 pong-node)
+   (! (tuple 'pong pong-node) 'finished)
+   (lfe_io:format "Ping finished~n" ()))
+  ((n pong-node)
+   (! (tuple 'pong pong-node) (tuple 'ping (self)))
+   (receive
+     ('pong (lfe_io:format "Ping received pong~n" ())))
+   (ping (- n 1) pong-node)))
+
+(defun pong ()
+  (receive
+    ('finished
+     (lfe_io:format "Pong finished~n" ()))
+    ((tuple 'ping ping-pid)
+     (lfe_io:format "Pong received ping~n" ())
+     (! ping-pid 'pong)
+     (pong))))
+
+(defun start-pong ()
+  (register 'pong (spawn 'tut21 'pong ())))
+
+(defun start-ping (pong-node)
+  (spawn 'tut21 'ping (list 3 pong-node)))

--- a/tut22.lfe
+++ b/tut22.lfe
@@ -1,0 +1,25 @@
+(defmodule tut22
+  (export (start 1) (ping 2) (pong 0)))
+
+(defun ping
+  ((0 pong-node)
+   (! (tuple 'pong pong-node) 'finished)
+   (lfe_io:format "Ping finished~n" ()))
+  ((n pong-node)
+   (! (tuple 'pong pong-node) (tuple 'ping (self)))
+   (receive
+     ('pong (lfe_io:format "Ping received pong~n" ())))
+   (ping (- n 1) pong-node)))
+
+(defun pong ()
+  (receive
+    ('finished
+     (lfe_io:format "Pong finished~n" ()))
+    ((tuple 'ping ping-pid)
+     (lfe_io:format "Pong received ping~n" ())
+     (! ping-pid 'pong)
+     (pong))))
+
+(defun start (ping-node)
+  (register 'pong (spawn 'tut22 'pong ()))
+  (spawn ping-node 'tut22 'ping (list 3 (node))))


### PR DESCRIPTION
## Summary
- implement `tut21.lfe` demonstrating ping/pong across nodes
- implement `tut22.lfe` showing remote process spawning

## Testing
- `dub test` *(fails: `dub` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2cd221dc8327b434bf5f1b16168c