### PR TITLE
Implement process linking and exit handling

### DIFF
--- a/tut20.lfe
+++ b/tut20.lfe
@@ -1,26 +1,26 @@
 (defmodule tut20
-  (export (start 0) (ping 1) (pong 0)))
+  (export (start 1) (ping 2) (pong 0)))
 
-(defun ping
-  ((0)
-   (! 'pong 'finished)
-   (lfe_io:format "Ping finished~n" ()))
-  ((n)
-   (! 'pong (tuple 'ping (self)))
+(defun ping (n pong-pid)
+  (link pong-pid)
+  (ping1 n pong-pid))
+
+(defun ping1
+  ((0 pong-pid)
+   (exit 'ping))
+  ((n pong-pid)
+   (! pong-pid (tuple 'ping (self)))
    (receive
      ('pong (lfe_io:format "Ping received pong~n" ())))
-   (ping (- n 1))))
+   (ping1 (- n 1) pong-pid)))
 
 (defun pong ()
   (receive
-    ('finished
-     (lfe_io:format "Pong finished~n" ()))
     ((tuple 'ping ping-pid)
      (lfe_io:format "Pong received ping~n" ())
      (! ping-pid 'pong)
      (pong))))
 
-(defun start ()
+(defun start (ping-node)
   (let ((pong-pid (spawn 'tut20 'pong ())))
-    (register 'pong pong-pid)
-    (spawn 'tut20 'ping '(3))))
+    (spawn ping-node 'tut20 'ping (list 3 pong-pid))))

--- a/tut21.lfe
+++ b/tut21.lfe
@@ -1,27 +1,32 @@
 (defmodule tut21
-  (export (start-ping 1) (start-pong 0) (ping 2) (pong 0)))
+  (export (start 1) (ping 2) (pong 0)))
 
-(defun ping
-  ((0 pong-node)
-   (! (tuple 'pong pong-node) 'finished)
-   (lfe_io:format "Ping finished~n" ()))
-  ((n pong-node)
-   (! (tuple 'pong pong-node) (tuple 'ping (self)))
+(defun ping (n pong-pid)
+  (link pong-pid)
+  (ping1 n pong-pid))
+
+(defun ping1
+  ((0 pong-pid)
+   (exit 'ping))
+  ((n pong-pid)
+   (! pong-pid (tuple 'ping (self)))
    (receive
      ('pong (lfe_io:format "Ping received pong~n" ())))
-   (ping (- n 1) pong-node)))
+   (ping1 (- n 1) pong-pid)))
 
 (defun pong ()
+  (process_flag 'trap_exit 'true)
+  (pong1))
+
+(defun pong1 ()
   (receive
-    ('finished
-     (lfe_io:format "Pong finished~n" ()))
     ((tuple 'ping ping-pid)
      (lfe_io:format "Pong received ping~n" ())
      (! ping-pid 'pong)
-     (pong))))
+     (pong1))
+    ((tuple 'EXIT from reason)
+     (lfe_io:format "Pong exiting, got ~p~n" (list (tuple 'EXIT from reason))))))
 
-(defun start-pong ()
-  (register 'pong (spawn 'tut21 'pong ())))
-
-(defun start-ping (pong-node)
-  (spawn 'tut21 'ping (list 3 pong-node)))
+(defun start (ping-node)
+  (let ((pong-pid (spawn 'tut21 'pong ())))
+    (spawn ping-node 'tut21 'ping (list 3 pong-pid))))


### PR DESCRIPTION
## Summary
- add `ExitException` and support for process links and `trap_exit`
- implement `link`, `spawn_link`, and `process_flag` builtins
- propagate exit signals to linked processes
- update tut20 and tut21 examples for linking and exit trapping

## Testing
- `dmd src/lferepl.d -of=lferepl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2ff20b408327b685bc77c1acdb29