### PR TITLE
Add macro support to LFE REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ lfe> (defun double (x) (* 2 x))
 0
 lfe> (double 21)
 42
+lfe> (defmacro unless (test body)
+      `(if (not ,test) ,body))
+0
+lfe> (unless (> 3 4) 'yes)
+yes
 lfe> (exit)
 ```
 


### PR DESCRIPTION
## Summary
- implement macro system with `defmacro` and `macroexpand`
- add recursive `macroExpand` expansion logic
- expand expressions before evaluation
- document macro usage in README

## Testing
- `ldc2 src/lferepl.d src/dlexer.d src/dparser.d -of=lferepl` *(fails: command not found)*
- `dmd src/lferepl.d src/dlexer.d src/dparser.d -of=lferepl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e34815434832797840f5f6ebd39fb