### PR TITLE
Add apropos builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ supports basic aliases using the `alias` builtin. You can repeat the previous
 command by typing `!!`.
 You can view a list of common Linux commands with the built-in `help` command,
 which prints the contents of `commands.txt`.
+The new `apropos` command searches this help text for a keyword so you can
+quickly look up related commands.
 
 These examples demonstrate how additional Bash commands can be layered on top of a Haskell-inspired syntax. The goal remains to eventually cover the full Bash command set, including job control and other special operators.
 

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -278,6 +278,22 @@ void runCommand(string cmd) {
             auto name = tokens[1];
             if(auto val = name in aliases) writeln(name, "=", *val);
         }
+    } else if(op == "apropos") {
+        if(tokens.length < 2) {
+            writeln("Usage: apropos keyword");
+            return;
+        }
+        string helpText;
+        try {
+            helpText = readText("commands.txt");
+        } catch(Exception e) {
+            writeln("commands.txt not found");
+            return;
+        }
+        auto pattern = tokens[1].toLower;
+        foreach(line; helpText.splitLines) {
+            if(line.toLower.canFind(pattern)) writeln(line);
+        }
     } else if(op == "help") {
         string helpText;
         try {


### PR DESCRIPTION
## Summary
- add an `apropos` command to search `commands.txt`
- document `apropos` usage in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e3ea5cfe483279e576904a4368616