### PR TITLE
Add bg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The interpreter now supports a broader set of commands:
 - directory commands like `cd`, `pwd`, and `ls`
 - Haskell-style `for` loops, e.g. `for 1..3 echo hi`
 - concurrent commands using `&`, e.g. `echo one & echo two`
+- `bg` to run a command in the background
 - sequential commands separated by `;`
 - file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, and `touch`
 - text display commands like `cat`, `head`, `tail`, and `grep`

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -54,6 +54,11 @@ void runParallel(string input) {
     }
 }
 
+void runBackground(string cmd) {
+    // Execute a command asynchronously without waiting
+    taskPool.put(() { run(cmd); });
+}
+
 void runCommand(string cmd) {
     history ~= cmd;
     auto tokens = cmd.split();
@@ -260,6 +265,13 @@ void runCommand(string cmd) {
         import std.datetime : Clock;
         auto now = Clock.currTime();
         writeln(now.toISOExtString());
+    } else if(op == "bg") {
+        if(tokens.length < 2) {
+            writeln("Usage: bg command");
+            return;
+        }
+        auto sub = tokens[1 .. $].join(" ");
+        runBackground(sub);
     } else if(op == "alias") {
         if(tokens.length == 1) {
             foreach(name, val; aliases) {


### PR DESCRIPTION
## Summary
- add `runBackground` helper to launch asynchronous commands
- implement `bg` builtin to run commands in the background
- document `bg` in README

## Testing
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3f8227708327aa5369b5421e36db