### PR TITLE
Add unalias builtin and expand alias features

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The interpreter now supports a broader set of commands:
 
 Running the interpreter with no command argument starts an interactive shell.
 You can customize the prompt text using the `PS1` environment variable and its color with `PS_COLOR` (e.g. `PS_COLOR=green`). Type `exit` to leave the shell.
-The shell now records command history which can be viewed with `history` and
-supports basic aliases using the `alias` builtin. You can repeat the previous
-command by typing `!!`.
+The shell now records command history which can be viewed with `history`.
+Aliases may be managed with the `alias` builtin and removed using `unalias`.
+You can repeat the previous command by typing `!!`.
 You can view a list of common Linux commands with the built-in `help` command,
 which prints the contents of `commands.txt`.
 The new `apropos` command searches this help text for a keyword so you can


### PR DESCRIPTION
## Summary
- allow listing, setting and querying aliases with `alias -p`
- implement `unalias` builtin to remove aliases
- handle recursive alias expansion
- mention alias management in README

## Testing
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e40c2a2e08327997d03a409d1685a