### PR TITLE
Add basic apt command handling

### DIFF
--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -383,6 +383,11 @@ void runCommand(string cmd) {
         foreach(i, cmdLine; history) {
             writeln(i + 1, " ", cmdLine);
         }
+    } else if(op == "apt" || op == "apt-get") {
+        auto rc = system(cmd);
+        if(rc != 0) {
+            writeln(op, " failed with code ", rc);
+        }
     } else {
         // attempt to run external command
         auto rc = system(cmd);


### PR DESCRIPTION
## Summary
- support `apt` and `apt-get` as recognized commands in the interpreter

## Testing
- `dmd src/interpreter.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4320a1c48327896fb45ccd2cd636