### PR TITLE
Add basename builtin

### DIFF
--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -280,6 +280,24 @@ void runCommand(string cmd) {
                     writeln(fields[fieldIdx - 1]);
             }
         }
+    } else if(op == "basename") {
+        if(tokens.length < 2) {
+            writeln("basename: missing operand");
+            return;
+        }
+        auto path = tokens[1];
+        string base;
+        auto pos = path.lastIndexOf('/');
+        if(pos >= 0)
+            base = path[pos + 1 .. $];
+        else
+            base = path;
+        if(tokens.length > 2) {
+            auto suf = tokens[2];
+            if(base.endsWith(suf))
+                base = base[0 .. $ - suf.length];
+        }
+        writeln(base);
     } else if(op == "mkdir") {
         if(tokens.length < 2) {
             writeln("mkdir: missing operand");


### PR DESCRIPTION
## Summary
- add builtin `basename` command to extract filename component

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685eb551dd4c83279e5b848879555bd2