### PR TITLE
Add base64 command support

### DIFF
--- a/src/base64.d
+++ b/src/base64.d
@@ -1,0 +1,83 @@
+module base64;
+
+import std.array : appender, Appender;
+import std.string : toLower;
+
+immutable string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+string base64Encode(const(ubyte)[] data, size_t wrap = 76)
+{
+    auto out = appender!string();
+    uint buffer = 0;
+    int bits = 0;
+    size_t line = 0;
+    foreach(b; data) {
+        buffer = (buffer << 8) | b;
+        bits += 8;
+        while(bits >= 6) {
+            auto idx = (buffer >> (bits - 6)) & 63;
+            out.put(alphabet[idx]);
+            bits -= 6;
+            line++;
+            if(wrap > 0 && line >= wrap) {
+                out.put('\n');
+                line = 0;
+            }
+        }
+    }
+    if(bits > 0) {
+        buffer <<= (6 - bits);
+        auto idx = buffer & 63;
+        out.put(alphabet[idx]);
+        line++;
+        if(wrap > 0 && line >= wrap) {
+            out.put('\n');
+            line = 0;
+        }
+    }
+    while(line % 4 != 0) {
+        out.put('=');
+        line++;
+        if(wrap > 0 && line >= wrap) {
+            out.put('\n');
+            line = 0;
+        }
+    }
+    return out.data;
+}
+
+ubyte[] base64Decode(string data, bool ignoreGarbage = false)
+{
+    int[256] map;
+    map[] = -1;
+    foreach(i, ch; alphabet) {
+        map[cast(ubyte)ch] = i;
+        map[cast(ubyte)toLower(ch)] = i;
+    }
+
+    auto out = appender!(ubyte[])();
+    uint buffer = 0;
+    int bits = 0;
+    foreach(ch; data) {
+        if(ch == '=' || ch == '\n' || ch == '\r')
+            continue;
+        int idx = -1;
+        if(cast(size_t)ch < map.length)
+            idx = map[cast(ubyte)ch];
+        if(idx == -1) {
+            if(ignoreGarbage)
+                continue;
+            else
+                break;
+        }
+        buffer = (buffer << 6) | cast(uint)idx;
+        bits += 6;
+        if(bits >= 8) {
+            auto byte = (buffer >> (bits - 8)) & 0xFF;
+            out.put(cast(ubyte)byte);
+            bits -= 8;
+        }
+    }
+    return out.data;
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -14,6 +14,7 @@ import core.thread : Thread;
 import std.datetime : Clock, SysTime;
 import core.time : dur;
 import base32;
+import base64;
 
 string[] history;
 string[string] aliases;
@@ -299,6 +300,68 @@ void runCommand(string cmd) {
                 base = base[0 .. $ - suf.length];
         }
         writeln(base);
+    } else if(op == "base64") {
+        bool decode = false;
+        bool ignore = false;
+        size_t wrapLen = 76;
+        string[] files;
+        size_t i = 1;
+        while(i < tokens.length) {
+            auto t = tokens[i];
+            if(t == "-d" || t == "--decode") {
+                decode = true;
+            } else if(t == "-i" || t == "--ignore-garbage") {
+                ignore = true;
+            } else if(t.startsWith("--wrap=")) {
+                wrapLen = to!size_t(t[7 .. $]);
+            } else if(t == "-w" || t == "--wrap") {
+                if(i + 1 < tokens.length) {
+                    wrapLen = to!size_t(tokens[i + 1]);
+                    i++;
+                }
+            } else if(t == "--help") {
+                writeln("Usage: base64 [OPTION]... [FILE]");
+                writeln("  -d, --decode          Decode data");
+                writeln("  -i, --ignore-garbage  Ignore non-alphabet characters");
+                writeln("  -w, --wrap=COLS       Wrap encoded lines after COLS (default 76)");
+                return;
+            } else if(t == "--version") {
+                writeln("base64 (shell builtin) 1.0");
+                return;
+            } else {
+                files ~= t;
+            }
+            i++;
+        }
+
+        auto process = (string txt) {
+            if(decode) {
+                auto bytes = base64Decode(txt, ignore);
+                writeln(cast(string)bytes);
+            } else {
+                auto encoded = base64Encode(cast(ubyte[])txt, wrapLen);
+                if(wrapLen == 0)
+                    write(encoded);
+                else
+                    writeln(encoded);
+            }
+        };
+
+        if(files.length == 0) {
+            string line;
+            while((line = readln()) !is null) {
+                process(line);
+            }
+        } else {
+            foreach(f; files) {
+                try {
+                    auto content = readText(f);
+                    process(content);
+                } catch(Exception e) {
+                    writeln("base64: cannot read ", f);
+                }
+            }
+        }
     } else if(op == "base32") {
         bool decode = false;
         bool ignore = false;


### PR DESCRIPTION
## Summary
- implement `base64` encoding/decoding utility in D
- wire `base64` command into the interpreter

## Testing
- `ldc2 src/interpreter.d src/base32.d src/base64.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb75520308327a2b05c50e8d31534