### PR TITLE
Add simple bc command

### DIFF
--- a/src/bc.d
+++ b/src/bc.d
@@ -1,0 +1,87 @@
+module bc;
+
+import dlexer;
+import std.regex : regex;
+import std.array : array;
+import std.algorithm : filter;
+import std.bigint : BigInt;
+import std.conv : to;
+
+class BCParser {
+    Token[] tokens;
+    size_t pos;
+
+    this(Token[] t) {
+        tokens = t;
+        pos = 0;
+    }
+
+    bool peek(string type) {
+        return pos < tokens.length && tokens[pos].type == type;
+    }
+
+    Token consume(string type) {
+        if(!peek(type))
+            throw new Exception("Expected " ~ type);
+        return tokens[pos++];
+    }
+
+    BigInt parseExpression() {
+        auto value = parseTerm();
+        while(peek("PLUS") || peek("MINUS")) {
+            auto op = consume(tokens[pos].type);
+            auto rhs = parseTerm();
+            final switch(op.type) {
+                case "PLUS":  value += rhs; break;
+                case "MINUS": value -= rhs; break;
+                default: break;
+            }
+        }
+        return value;
+    }
+
+    BigInt parseTerm() {
+        auto value = parseFactor();
+        while(peek("TIMES") || peek("DIVIDE")) {
+            auto op = consume(tokens[pos].type);
+            auto rhs = parseFactor();
+            final switch(op.type) {
+                case "TIMES":  value *= rhs; break;
+                case "DIVIDE": value /= rhs; break;
+                default: break;
+            }
+        }
+        return value;
+    }
+
+    BigInt parseFactor() {
+        if(peek("NUMBER")) {
+            auto t = consume("NUMBER");
+            return BigInt(t.value);
+        } else if(peek("LPAREN")) {
+            consume("LPAREN");
+            auto val = parseExpression();
+            consume("RPAREN");
+            return val;
+        }
+        throw new Exception("Unexpected token");
+    }
+}
+
+BigInt bcEval(string expr) {
+    auto rules = [
+        Rule("NUMBER", regex("[0-9]+")),
+        Rule("PLUS", regex("\\+")),
+        Rule("MINUS", regex("-")),
+        Rule("TIMES", regex("\\*")),
+        Rule("DIVIDE", regex("/")),
+        Rule("LPAREN", regex("\\(")),
+        Rule("RPAREN", regex("\\)")),
+        Rule("WS", regex("\\s+"))
+    ];
+    auto lex = new Lexer(rules);
+    auto tokens = lex.tokenize(expr);
+    tokens = tokens.filter!(t => t.type != "WS").array;
+    auto parser = new BCParser(tokens);
+    return parser.parseExpression();
+}

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -15,6 +15,7 @@ import std.datetime : Clock, SysTime;
 import core.time : dur;
 import base32;
 import base64;
+import bc;
 
 string[] history;
 string[string] aliases;
@@ -129,6 +130,18 @@ void runCommand(string cmd) {
             case "/": result = b == 0 ? 0 : a / b; break;
         }
         writeln(result);
+    } else if(op == "bc") {
+        if(tokens.length < 2) {
+            writeln("Usage: bc expression");
+            return;
+        }
+        auto expr = tokens[1 .. $].join(" ");
+        try {
+            auto res = bcEval(expr);
+            writeln(res);
+        } catch(Exception e) {
+            writeln("bc: invalid expression");
+        }
     } else if(op == "for") {
         if(tokens.length < 3) {
             writeln("Usage: for start..end command");


### PR DESCRIPTION
## Summary
- import `bc` module in interpreter
- add a `bc` builtin using `bcEval`
- implement a `bcEval` function that parses big integer arithmetic with a small lexer and parser

## Testing
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1fccb50832799649932ed4329e2