### PR TITLE
Implement minimal bind builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can customize the prompt text using the `PS1` environment variable and its c
 The shell now records command history which can be viewed with `history`.
 Aliases may be managed with the `alias` builtin and removed using `unalias`.
 You can repeat the previous command by typing `!!`.
+Key sequences can be associated with commands using the `bind -x` builtin.
 You can view a list of common Linux commands with the built-in `help` command,
 which prints the contents of `commands.txt`.
 The `apropos` command searches this help text for matching commands. It now


### PR DESCRIPTION
## Summary
- add a `keyBindings` table for custom key actions
- implement a basic `bind` builtin that supports `-x`, `-r`, `-f` and listing
- trigger bound commands in the REPL
- document use of `bind -x` in README

## Testing
- `dmd -c src/interpreter.d src/base32.d src/base64.d src/bc.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ec46a1d348327a0d2b4d14c1c824f