### PR TITLE
Add bzip2 wrapper builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The interpreter now supports a broader set of commands:
 - text display commands like `cat`, `head`, `tail`, and `grep`
 - `date` for the current time
 - schedule commands using `at`
+- compression utilities with `bzip2`
 
 Running the interpreter with no command argument starts an interactive shell.
 You can customize the prompt text using the `PS1` environment variable and its color with `PS_COLOR` (e.g. `PS_COLOR=green`). Type `exit` to leave the shell.

--- a/commands.txt
+++ b/commands.txt
@@ -20,6 +20,9 @@ B
     break    Exit from a loop
     builtin    Run a shell builtin
     bzip2    Compress or decompress named file(s)
+    bunzip2    Decompress .bz2 files
+    bzcat    Decompress to standard output
+    bzip2recover    Recover data from damaged .bz2 files
 C
     cal    Display a calendar
     caller    Return the context of any active subroutine call

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -491,6 +491,18 @@ void runCommand(string cmd, bool skipAlias=false) {
                 }
             }
         }
+    } else if(op == "bzip2" || op == "bunzip2" || op == "bzcat" || op == "bzip2recover") {
+        auto args = tokens[1 .. $].join(" ");
+        string cmdLine;
+        if(op == "bunzip2")
+            cmdLine = "bzip2 -d " ~ args;
+        else if(op == "bzcat")
+            cmdLine = "bzip2 -dc " ~ args;
+        else
+            cmdLine = op ~ (args.length ? " " ~ args : "");
+        auto rc = system(cmdLine);
+        if(rc != 0)
+            writeln(op, " failed with code ", rc);
     } else if(op == "mkdir") {
         if(tokens.length < 2) {
             writeln("mkdir: missing operand");


### PR DESCRIPTION
## Summary
- add `bzip2` command wrapper with support for `bunzip2`, `bzcat`, and `bzip2recover`
- document bzip2 in the README
- list bunzip2, bzcat and bzip2recover in `commands.txt`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685eceaa0c0c8327a2af9c2b80f596b2