### PR TITLE
Add chattr builtin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The interpreter now supports a broader set of commands:
 - `bg` to run a command in the background or resume a stopped job
 - `jobs` to list background jobs
 - sequential commands separated by `;`
-- file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, and `touch`
+- file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, and `chattr`
 - text display commands like `cat`, `head`, `tail`, and `grep`
 - `date` for the current time
 - schedule commands using `at`

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -747,6 +747,15 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 writeln("rm: cannot remove ", f);
             }
         }
+    } else if(op == "chattr") {
+        if(tokens.length < 2) {
+            writeln("Usage: chattr [options] mode files...");
+            return;
+        }
+        auto args = tokens[1 .. $].join(" ");
+        auto rc = system("chattr " ~ args);
+        if(rc != 0)
+            writeln("chattr failed with code ", rc);
     } else if(op == "cfdisk") {
         string optP;
         string device = "/dev/vda";


### PR DESCRIPTION
## Summary
- implement `chattr` by calling the system utility
- mention `chattr` in list of file utilities

## Testing
- `dmd -c src/interpreter.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed9e0a54c8327b6ef37fc9faee9bd