### PR TITLE
Add chown builtin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The interpreter now supports a broader set of commands:
 - `bg` to run a command in the background or resume a stopped job
 - `jobs` to list background jobs
 - sequential commands separated by `;`
-- file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, and `chattr`
+- file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, `chattr`, and `chown`
 - text display commands like `cat`, `head`, `tail`, and `grep`
 - `date` for the current time
 - schedule commands using `at`

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -766,6 +766,16 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         auto rc = system("chgrp " ~ args);
         if(rc != 0)
             writeln("chgrp failed with code ", rc);
+    } else if(op == "chown") {
+        if(tokens.length < 3 &&
+           !(tokens.length >= 2 && tokens[1].startsWith("--reference="))) {
+            writeln("Usage: chown owner[:group] file...");
+            return;
+        }
+        auto args = tokens[1 .. $].join(" ");
+        auto rc = system("chown " ~ args);
+        if(rc != 0)
+            writeln("chown failed with code ", rc);
     } else if(op == "chmod") {
         if(tokens.length < 3 &&
            !(tokens.length >= 2 && tokens[1].startsWith("--reference="))) {


### PR DESCRIPTION
## Summary
- add `chown` implementation to the shell interpreter
- mention `chown` in README file utilities list

## Testing
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edc6a55108327964a2f775dcf3dc1