### PR TITLE
Add comm builtin command

### DIFF
--- a/src/comm.d
+++ b/src/comm.d
@@ -1,0 +1,69 @@
+module comm;
+
+import std.stdio;
+import std.file : readText;
+import std.string : splitLines;
+
+string[] readLines(string name)
+{
+    string[] lines;
+    if(name == "-") {
+        foreach(line; stdin.byLine())
+            lines ~= line.idup;
+    } else {
+        try {
+            auto content = readText(name);
+            lines = content.splitLines();
+        } catch(Exception) {
+            writeln("comm: cannot read ", name);
+        }
+    }
+    return lines;
+}
+
+bool isSorted(string[] arr)
+{
+    foreach(i; 1 .. arr.length)
+        if(arr[i-1] > arr[i])
+            return false;
+    return true;
+}
+
+string repeatDelim(string d, int n)
+{
+    string out;
+    foreach(i; 0 .. n) out ~= d;
+    return out;
+}
+
+void commFiles(string f1, string f2, bool s1=false, bool s2=false, bool s3=false,
+               bool checkOrder=false, string delim="\t")
+{
+    auto a = readLines(f1);
+    auto b = readLines(f2);
+    if(checkOrder) {
+        if(!isSorted(a)) { writeln("comm: ", f1, " is not in sorted order"); return; }
+        if(!isSorted(b)) { writeln("comm: ", f2, " is not in sorted order"); return; }
+    }
+    size_t i=0, j=0;
+    int pad2 = s1 ? 0 : 1;
+    int pad3 = 0; if(!s1) pad3++; if(!s2) pad3++;
+    while(i < a.length && j < b.length) {
+        auto l1 = a[i];
+        auto l2 = b[j];
+        int cmp = (l1 < l2) ? -1 : ((l1 > l2) ? 1 : 0);
+        if(cmp < 0) {
+            if(!s1) writeln(l1);
+            i++;
+        } else if(cmp > 0) {
+            if(!s2) writeln(repeatDelim(delim, pad2) ~ l2);
+            j++;
+        } else {
+            if(!s3) writeln(repeatDelim(delim, pad3) ~ l1);
+            i++; j++;
+        }
+    }
+    while(i < a.length) { if(!s1) writeln(a[i]); i++; }
+    while(j < b.length) { if(!s2) writeln(repeatDelim(delim, pad2) ~ b[j]); j++; }
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -21,6 +21,7 @@ import cal;
 import chkconfig;
 import cksum;
 import cmp;
+import comm;
 
 string[] history;
 string[string] aliases;
@@ -957,6 +958,46 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         string file2 = (idx + 1 < tokens.length) ? tokens[idx + 1] : "-";
 
         cmp.cmpFiles(file1, file2, ignore, optC, optL, optSilent);
+    } else if(op == "comm") {
+        bool s1 = false;
+        bool s2 = false;
+        bool s3 = false;
+        bool check = false;
+        string delim = "\t";
+        size_t idx = 1;
+        while(idx < tokens.length && tokens[idx].startsWith("-")) {
+            auto t = tokens[idx];
+            if(t == "-1") s1 = true;
+            else if(t == "-2") s2 = true;
+            else if(t == "-3") s3 = true;
+            else if(t == "--check-order") check = true;
+            else if(t == "--nocheck-order") check = false;
+            else if(t.startsWith("--output-delimiter="))
+                delim = t[19 .. $];
+            else if(t == "--output-delimiter") {
+                if(idx + 1 < tokens.length) { delim = tokens[idx + 1]; idx++; }
+            } else if(t == "--version") {
+                writeln("comm (shell builtin) 1.0");
+                return;
+            } else if(t == "--help") {
+                writeln("Usage: comm [OPTION]... FILE1 FILE2");
+                return;
+            } else if(t == "--") {
+                idx++;
+                break;
+            } else {
+                break;
+            }
+            idx++;
+        }
+        if(idx + 1 >= tokens.length) {
+            writeln("Usage: comm [OPTION]... FILE1 FILE2");
+            return;
+        }
+        string file1 = tokens[idx];
+        string file2 = tokens[idx + 1];
+
+        comm.commFiles(file1, file2, s1, s2, s3, check, delim);
     } else if(op == "cal") {
         bool monday = false;
         bool yearFlag = false;


### PR DESCRIPTION
## Summary
- implement a new `comm` module that compares two sorted files
- support flags `-1`, `-2`, `-3`, `--check-order`, and `--output-delimiter`
- add `comm` handling in the interpreter

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ee53c6520832791030c9e5971132e