### PR TITLE
Add minimal cpio support via LFE builtins

### DIFF
--- a/src/cpio.d
+++ b/src/cpio.d
@@ -1,0 +1,111 @@
+module cpio;
+
+import std.stdio;
+import std.file : read, write, dirEntries, SpanMode, mkdir, FileException,
+                  isDir, getSize;
+import std.conv : to;
+import std.path : baseName;
+import std.format : format;
+
+struct Header {
+    uint ino;
+    uint mode;
+    uint uid;
+    uint gid;
+    uint nlink;
+    uint mtime;
+    uint filesize;
+    uint devmajor;
+    uint devminor;
+    uint rdevmajor;
+    uint rdevminor;
+    uint namesize;
+}
+
+void writeHeader(File f, string name, bool dir, ulong size) {
+    Header h;
+    h.ino = 0;
+    h.mode = dir ? 0x41ED : 0x81A4;
+    h.uid = 0;
+    h.gid = 0;
+    h.nlink = 1;
+    h.mtime = cast(uint)Clock.currTime.toUnixTime;
+    h.filesize = cast(uint)size;
+    h.devmajor = 0;
+    h.devminor = 0;
+    h.rdevmajor = 0;
+    h.rdevminor = 0;
+    h.namesize = cast(uint)(name.length + 1);
+    f.write("070701");
+    foreach(field; [h.ino, h.mode, h.uid, h.gid, h.nlink, h.mtime,
+                    h.filesize, h.devmajor, h.devminor, h.rdevmajor,
+                    h.rdevminor, h.namesize, 0u])
+    {
+        f.write(format("%08X", field));
+    }
+    f.write(name);
+    f.write('\0');
+    while((f.tell % 4) != 0) f.write('\0');
+}
+
+void createArchive(string archive, string[] files) {
+    auto out = File(archive, "wb");
+    foreach(path; files) {
+        bool dir = isDir(path);
+        auto name = baseName(path);
+        ulong size = dir ? 0 : getSize(path);
+        writeHeader(out, name, dir, size);
+        if(!dir)
+            out.rawWrite(read(path));
+        while((out.tell % 4) != 0) out.write('\0');
+    }
+    // trailer
+    out.write("07070100000000000000000000000000000000000000000000000000000000000000000000000B00000000TRAILER!!!\0");
+    while((out.tell % 4) != 0) out.write('\0');
+    out.close();
+}
+
+struct Entry {
+    string name;
+    bool isDir;
+    ubyte[] data;
+}
+
+Entry[] readArchive(string archive) {
+    Entry[] entries;
+    auto f = File(archive, "rb");
+    while(!f.eof) {
+        auto magic = cast(string)f.read(6);
+        if(magic.length == 0) break;
+        auto rest = cast(string)f.read(104);
+        if(magic != "070701") break;
+        uint[13] fields;
+        foreach(i; 0..13) {
+            auto hex = rest[i*8 .. i*8+8];
+            fields[i] = to!uint("0x" ~ hex);
+        }
+        auto namesize = fields[11];
+        auto fname = cast(string)f.read(namesize);
+        fname = fname[0 .. $-1];
+        while((f.tell % 4) != 0) f.read(1);
+        auto filesize = fields[6];
+        ubyte[] content;
+        if(filesize > 0) content = f.read(filesize);
+        while((f.tell % 4) != 0) f.read(1);
+        if(fname == "TRAILER!!!") break;
+        entries ~= Entry(fname, fields[2] & 0x4000 != 0, content);
+    }
+    f.close();
+    return entries;
+}
+
+void extractArchive(string archive) {
+    auto entries = readArchive(archive);
+    foreach(e; entries) {
+        if(e.isDir) {
+            mkdir(e.name, 0o755);
+        } else {
+            write(e.name, e.data);
+        }
+    }
+}

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -10,6 +10,7 @@ import std.algorithm;
 import std.conv : to;
 import std.file : readText, copy;
 import std.parallelism;
+import cpio : createArchive, extractArchive;
 import core.sync.mutex : Mutex;
 import core.sync.condition : Condition;
 
@@ -1011,6 +1012,28 @@ Value evalList(Expr e) {
             writeln("cp: failed to copy ", src, " to ", dst);
             return atomVal("error");
         }
+    } else if(head == "cpio-create") {
+        if(e.list.length < 3) return atomVal("error");
+        auto archVal = evalExpr(e.list[1]);
+        string arch = valueToString(archVal);
+        if(arch.length >= 2 && arch[0] == '"' && arch[$-1] == '"')
+            arch = arch[1 .. $-1];
+        string[] files;
+        foreach(expr; e.list[2 .. $]) {
+            string p = valueToString(evalExpr(expr));
+            if(p.length >= 2 && p[0] == '"' && p[$-1] == '"')
+                p = p[1 .. $-1];
+            files ~= p;
+        }
+        createArchive(arch, files);
+        return atomVal("ok");
+    } else if(head == "cpio-extract") {
+        auto archVal = evalExpr(e.list[1]);
+        string arch = valueToString(archVal);
+        if(arch.length >= 2 && arch[0] == '"' && arch[$-1] == '"')
+            arch = arch[1 .. $-1];
+        extractArchive(arch);
+        return atomVal("ok");
     } else if(head == "proplists:get_value") {
         auto key = evalExpr(e.list[1]);
         auto plist = evalExpr(e.list[2]);


### PR DESCRIPTION
## Summary
- implement a simple cpio archive creator/extractor in `src/cpio.d`
- expose new builtins `cpio-create` and `cpio-extract` in the LFE REPL

## Testing
- `ldc2 src/lferepl.d src/dlexer.d src/dparser.d src/cpio.d -of=lferepl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee978d654832796409724bd7cae44