### PR TITLE
Add cron daemon implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The interpreter now supports a broader set of commands:
 - text display commands like `cat`, `head`, `tail`, and `grep`
 - `date` for the current time
 - schedule commands using `at`
+- run recurring scheduled jobs with `cron`
 - compression utilities with `bzip2`
 - manage service runlevels with `chkconfig`
 - `caller` to display the current call stack frame

--- a/src/cron.d
+++ b/src/cron.d
@@ -1,0 +1,103 @@
+module cron;
+
+import std.stdio;
+import std.file : readText, exists;
+import std.datetime : Clock, SysTime;
+import std.process : system;
+import std.conv : to;
+import std.algorithm : splitter;
+import core.thread : Thread;
+import core.time : dur;
+
+struct CronJob {
+    bool[60] mins;
+    bool[24] hours;
+    bool[32] dom; // 1-31
+    bool[13] months; //1-12
+    bool[7] dow; //0-6
+    string cmd;
+}
+
+CronJob[] jobs;
+
+bool[] parseField(string field, int minVal, int maxVal) {
+    bool[] mask;
+    mask.length = maxVal + 1;
+    foreach(part; splitter(field, ',')) {
+        auto p = part.strip;
+        if(p == "*") {
+            foreach(i; minVal..maxVal+1) mask[i] = true;
+            continue;
+        }
+        int step = 1;
+        string range = p;
+        auto slash = p.indexOf('/');
+        if(slash >= 0) {
+            range = p[0..slash];
+            step = to!int(p[slash+1..$]);
+        }
+        int start = minVal;
+        int end = maxVal;
+        auto dash = range.indexOf('-');
+        if(range != "*") {
+            if(dash >= 0) {
+                start = to!int(range[0..dash]);
+                end = to!int(range[dash+1..$]);
+            } else {
+                start = to!int(range);
+                end = start;
+            }
+        }
+        foreach(i; start..end+1 by step) {
+            if(i >= minVal && i <= maxVal) mask[i] = true;
+        }
+    }
+    return mask;
+}
+
+void loadCrontab(string path) {
+    jobs.length = 0;
+    if(!exists(path)) return;
+    foreach(line; readText(path).splitLines) {
+        auto t = line.strip;
+        if(t.length == 0 || t.startsWith("#")) continue;
+        auto parts = t.split();
+        if(parts.length < 6) continue;
+        CronJob job;
+        job.mins = parseField(parts[0],0,59).dup[0..60];
+        job.hours = parseField(parts[1],0,23).dup[0..24];
+        job.dom = parseField(parts[2],1,31).dup[0..32];
+        job.months = parseField(parts[3],1,12).dup[0..13];
+        job.dow = parseField(parts[4],0,6).dup[0..7];
+        job.cmd = parts[5..$].join(" ");
+        jobs ~= job;
+    }
+}
+
+void runCron(string path) {
+    loadCrontab(path);
+    int lastMin = -1;
+    for(;;) {
+        auto now = Clock.currTime();
+        if(now.minute != lastMin) {
+            lastMin = now.minute;
+            foreach(job; jobs) {
+                if(job.mins[now.minute] &&
+                   job.hours[now.hour] &&
+                   job.dom[now.day] &&
+                   job.months[now.month] &&
+                   job.dow[now.dayOfWeek]) {
+                    system(job.cmd);
+                }
+            }
+        }
+        Thread.sleep(dur!"seconds"(1));
+    }
+}
+
+void cronCommand(string[] args) {
+    string path = "crontab";
+    if(args.length > 1) path = args[1];
+    runCron(path);
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -22,6 +22,7 @@ import chkconfig;
 import cksum;
 import cmp;
 import comm;
+import cron;
 
 string[] history;
 string[string] aliases;
@@ -1046,6 +1047,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         string file2 = tokens[idx + 1];
 
         comm.commFiles(file1, file2, s1, s2, s3, check, delim);
+    } else if(op == "cron") {
+        cronCommand(tokens);
     } else if(op == "cal") {
         bool monday = false;
         bool yearFlag = false;


### PR DESCRIPTION
## Summary
- implement recurring job scheduler in `cron.d`
- hook `cron` command into interpreter
- document cron capability in README

## Testing
- `ldc2` unavailable, so build/tests not run

------
https://chatgpt.com/codex/tasks/task_e_685eebee7b948327953f381abd64fc9d