### PR TITLE
Add crontab command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ The interpreter now supports a broader set of commands:
 - file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, `chattr`, and `chown`
 - text display commands like `cat`, `head`, `tail`, and `grep`
 - `date` for the current time
-- schedule commands using `at`
-- run recurring scheduled jobs with `cron`
+ - schedule commands using `at`
+ - run recurring scheduled jobs with `cron`
+ - manage cron tables with `crontab`
 - compression utilities with `bzip2`
 - manage service runlevels with `chkconfig`
 - `caller` to display the current call stack frame

--- a/src/crontab.d
+++ b/src/crontab.d
@@ -1,0 +1,76 @@
+module crontab;
+
+import std.stdio;
+import std.file : readText, write, exists, remove;
+import std.process : environment, system;
+
+void editFile(string path)
+{
+    string editor;
+    if(auto e = environment.get("VISUAL"))
+        editor = e;
+    else if(auto e2 = environment.get("EDITOR"))
+        editor = e2;
+    else
+        editor = "vi";
+    system(editor ~ " " ~ path);
+}
+
+void installFile(string src, string dest)
+{
+    try {
+        auto text = readText(src);
+        write(dest, text);
+    } catch(Exception) {
+        writeln("crontab: cannot read " ~ src);
+    }
+}
+
+void crontabCommand(string[] args)
+{
+    string path = "crontab";
+    bool listFlag = false;
+    bool removeFlag = false;
+    bool editFlag = false;
+
+    size_t idx = 1;
+    while(idx < args.length && args[idx].startsWith("-")) {
+        auto t = args[idx];
+        if(t == "-l") {
+            listFlag = true;
+        } else if(t == "-r") {
+            removeFlag = true;
+        } else if(t == "-e") {
+            editFlag = true;
+        } else if(t == "-u") {
+            idx++; // skip user name
+        }
+        idx++;
+    }
+
+    string file;
+    if(idx < args.length)
+        file = args[idx];
+
+    if(listFlag) {
+        if(exists(path))
+            writeln(readText(path));
+        return;
+    }
+    if(removeFlag) {
+        if(exists(path)) remove(path);
+        return;
+    }
+    if(editFlag) {
+        if(!exists(path)) write(path, "");
+        editFile(path);
+        return;
+    }
+    if(file.length) {
+        installFile(file, path);
+        return;
+    }
+
+    writeln("Usage: crontab [-l|-r|-e] [file]");
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -23,6 +23,7 @@ import cksum;
 import cmp;
 import comm;
 import cron;
+import crontab;
 
 string[] history;
 string[string] aliases;
@@ -1049,6 +1050,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         comm.commFiles(file1, file2, s1, s2, s3, check, delim);
     } else if(op == "cron") {
         cronCommand(tokens);
+    } else if(op == "crontab") {
+        crontabCommand(tokens);
     } else if(op == "cal") {
         bool monday = false;
         bool yearFlag = false;


### PR DESCRIPTION
## Summary
- implement a basic `crontab` command for managing cron tables
- wire `crontab` into the interpreter
- document `crontab` in README

## Testing
- `dmd --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eed575d5c832786484ea604491b8a