### PR TITLE
Implement date command with formatting

### DIFF
--- a/src/date.d
+++ b/src/date.d
@@ -1,0 +1,91 @@
+module date;
+
+import std.stdio;
+import std.datetime : Clock, SysTime, DateTime;
+import std.conv : to;
+import std.string : split;
+
+SysTime parseDateString(string s) {
+    try {
+        auto parts = s.split(" ");
+        auto date = parts[0].split("-");
+        if(date.length < 3) return Clock.currTime();
+        int year = to!int(date[0]);
+        int month = to!int(date[1]);
+        int day = to!int(date[2]);
+        int hour = 0, minute = 0, second = 0;
+        if(parts.length > 1) {
+            auto time = parts[1].split(":");
+            hour = to!int(time[0]);
+            if(time.length > 1) minute = to!int(time[1]);
+            if(time.length > 2) second = to!int(time[2]);
+        }
+        auto dt = DateTime(year, month, day, hour, minute, second);
+        return SysTime(dt);
+    } catch(Exception) {
+        return Clock.currTime();
+    }
+}
+
+string two(int n) {
+    return n < 10 ? "0" ~ to!string(n) : to!string(n);
+}
+
+string four(int n) {
+    if(n < 10) return "000" ~ to!string(n);
+    if(n < 100) return "00" ~ to!string(n);
+    if(n < 1000) return "0" ~ to!string(n);
+    return to!string(n);
+}
+
+string formatDate(SysTime t, string fmt) {
+    string out;
+    for(size_t i=0; i<fmt.length; ++i) {
+        if(fmt[i] == '%' && i + 1 < fmt.length) {
+            auto c = fmt[i+1];
+            switch(c) {
+                case '%': out ~= "%"; break;
+                case 'Y': out ~= four(t.year); break;
+                case 'm': out ~= two(t.month); break;
+                case 'd': out ~= two(t.day); break;
+                case 'H': out ~= two(t.hour); break;
+                case 'M': out ~= two(t.minute); break;
+                case 'S': out ~= two(t.second); break;
+                case 'F': out ~= four(t.year) ~ "-" ~ two(t.month) ~ "-" ~ two(t.day); break;
+                case 'T': out ~= two(t.hour) ~ ":" ~ two(t.minute) ~ ":" ~ two(t.second); break;
+                default: out ~= "%" ~ c; break;
+            }
+            i++;
+        } else {
+            out ~= fmt[i];
+        }
+    }
+    return out;
+}
+
+void dateCommand(string[] tokens) {
+    SysTime time = Clock.currTime();
+    bool utc = false;
+    string fmt = "%c";
+    size_t idx = 1;
+    while(idx < tokens.length) {
+        auto t = tokens[idx];
+        if(t == "-u" || t == "--utc" || t == "--universal") {
+            utc = true;
+        } else if(t.startsWith("--date=")) {
+            time = parseDateString(t[7 .. $]);
+        } else if(t == "-d" && idx + 1 < tokens.length) {
+            time = parseDateString(tokens[idx+1]);
+            idx++;
+        } else if(t.length > 0 && t[0] == '+') {
+            fmt = t[1 .. $];
+        }
+        idx++;
+    }
+    if(utc) time = time.toUTC();
+    if(fmt == "%c")
+        writeln(time.toISOExtString());
+    else
+        writeln(formatDate(time, fmt));
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -26,6 +26,7 @@ import cron;
 import crontab;
 import csplit;
 import cut;
+import date;
 
 string[] history;
 string[string] aliases;
@@ -1145,9 +1146,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 writeln(frame.line, " ", frame.file);
         }
     } else if(op == "date") {
-        import std.datetime : Clock;
-        auto now = Clock.currTime();
-        writeln(now.toISOExtString());
+        dateCommand(tokens);
     } else if(op == "bg") {
         if(tokens.length == 1) {
             if(bgJobs.length == 0) {


### PR DESCRIPTION
## Summary
- add a `date` module implementing a simple `date` command
- support `-d`, `--date`, `-u` and format strings
- wire the shell interpreter to use `dateCommand`

## Testing
- `ldc2 src/interpreter.d src/base32.d src/base64.d src/bc.d src/cal.d src/chkconfig.d src/cksum.d src/cmp.d src/comm.d src/cron.d src/crontab.d src/csplit.d src/cut.d src/date.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef1095a7c8327bd5cb50e195e60c9