### PR TITLE
Add simple dc calculator support

### DIFF
--- a/src/dc.d
+++ b/src/dc.d
@@ -1,0 +1,75 @@
+module dc;
+
+import std.bigint : BigInt;
+import std.conv : to;
+import std.string : split, strip;
+
+string dcEval(string expr) {
+    BigInt[] stack;
+    string output;
+    foreach(token; split(expr)) {
+        final switch(token) {
+            case "":
+                break;
+            case "+":
+                if(stack.length < 2) throw new Exception("stack underflow");
+                auto b = stack[$-1];
+                auto a = stack[$-2];
+                stack.length -= 2;
+                stack ~= a + b;
+                break;
+            case "-":
+                if(stack.length < 2) throw new Exception("stack underflow");
+                auto b = stack[$-1];
+                auto a = stack[$-2];
+                stack.length -= 2;
+                stack ~= a - b;
+                break;
+            case "*":
+                if(stack.length < 2) throw new Exception("stack underflow");
+                auto b = stack[$-1];
+                auto a = stack[$-2];
+                stack.length -= 2;
+                stack ~= a * b;
+                break;
+            case "/":
+                if(stack.length < 2) throw new Exception("stack underflow");
+                auto b = stack[$-1];
+                auto a = stack[$-2];
+                stack.length -= 2;
+                stack ~= b == 0 ? BigInt(0) : a / b;
+                break;
+            case "p":
+                if(stack.length > 0)
+                    output ~= to!string(stack[$-1]) ~ "\n";
+                break;
+            case "f":
+                foreach(val; stack)
+                    output ~= to!string(val) ~ "\n";
+                break;
+            case "c":
+                stack.length = 0;
+                break;
+            case "d":
+                if(stack.length < 1) throw new Exception("stack underflow");
+                stack ~= stack[$-1];
+                break;
+            case "r":
+                if(stack.length < 2) throw new Exception("stack underflow");
+                auto tmp = stack[$-1];
+                stack[$-1] = stack[$-2];
+                stack[$-2] = tmp;
+                break;
+            default:
+                try {
+                    stack ~= BigInt(token);
+                } catch(Exception) {
+                    // ignore invalid tokens
+                }
+                break;
+        }
+    }
+    if(output.length && output[$-1] == '\n')
+        output = output[0 .. $-1];
+    return output;
+}

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -17,6 +17,7 @@ import core.time : dur;
 import base32;
 import base64;
 import bc;
+import dc;
 import cal;
 import chkconfig;
 import cksum;
@@ -242,6 +243,19 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             writeln(res);
         } catch(Exception e) {
             writeln("bc: invalid expression");
+        }
+    } else if(op == "dc") {
+        if(tokens.length < 2) {
+            writeln("Usage: dc expression");
+            return;
+        }
+        auto expr = tokens[1 .. $].join(" ");
+        try {
+            auto res = dcEval(expr);
+            if(res.length > 0)
+                writeln(res);
+        } catch(Exception e) {
+            writeln("dc: invalid expression");
         }
     } else if(op == "for") {
         if(tokens.length < 3) {


### PR DESCRIPTION
## Summary
- implement a small reverse polish calculator in D
- wire new `dc` command into the interpreter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ef2be1dc88327807946ab0cab30fe