### PR TITLE
Add simple declare builtin

### DIFF
--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -1250,6 +1250,42 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 }
             }
         }
+    } else if(op == "declare") {
+        bool print = false;
+        bool exportVar = false;
+        size_t idx = 1;
+        while(idx < tokens.length && tokens[idx].startsWith("-")) {
+            foreach(ch; tokens[idx][1 .. $]) {
+                final switch(ch) {
+                    case 'p': print = true; break;
+                    case 'x': exportVar = true; break;
+                    default: break;
+                }
+            }
+            idx++;
+        }
+
+        if(idx >= tokens.length) {
+            foreach(name, val; variables) {
+                writeln(name, "=\"", val, "\"");
+            }
+        } else {
+            foreach(arg; tokens[idx .. $]) {
+                auto eq = arg.indexOf('=');
+                string name;
+                string value;
+                if(eq > 0) {
+                    name = arg[0 .. eq];
+                    value = arg[eq+1 .. $];
+                    variables[name] = value;
+                    if(exportVar) environment[name] = value;
+                } else {
+                    name = arg;
+                    if(auto val = name in variables) value = *val; else value = "";
+                }
+                if(print) writeln(name, "=\"", value, "\"");
+            }
+        }
     } else if(op == "unalias") {
         if(tokens.length == 2 && tokens[1] == "-a") {
             aliases.clear();


### PR DESCRIPTION
## Summary
- add a minimal implementation of the `declare` builtin

## Testing
- `ldc2 src/interpreter.d src/base32.d src/base64.d src/bc.d src/cal.d src/chkconfig.d src/cksum.d src/cmp.d src/comm.d src/cpio.d src/cron.d src/crontab.d src/csplit.d src/cut.d src/date.d src/dc.d src/dd.d src/ddrescue.d src/dlexer.d src/dparser.d src/lfe.d src/lferepl.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef70b84f48327b53d7f07d1cc9147