### PR TITLE
Add dir*, dircolors and dirname commands

### DIFF
--- a/src/dir.d
+++ b/src/dir.d
@@ -1,0 +1,37 @@
+module dir;
+
+import std.stdio;
+import std.file : dirEntries, SpanMode;
+import std.algorithm : sort;
+import std.format : format;
+
+string escapeName(string name)
+{
+    string out;
+    foreach(dchar c; name) {
+        if(c == '\\')
+            out ~= "\\\\";
+        else if(c < 32 || c == 127)
+            out ~= "\\" ~ format("%03o", cast(int)c);
+        else
+            out ~= cast(char)c;
+    }
+    return out;
+}
+
+void dirCommand(string[] tokens)
+{
+    string path = tokens.length > 1 ? tokens[1] : ".";
+    string[] entries;
+    foreach(e; dirEntries(path, SpanMode.shallow))
+        entries ~= e.name;
+    entries.sort;
+    size_t cols = 4;
+    for(size_t i=0;i<entries.length;i++) {
+        auto n = escapeName(entries[i]);
+        writef("%-20s", n);
+        if((i+1)%cols==0 || i+1==entries.length)
+            writeln();
+    }
+}
+

--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -1,0 +1,60 @@
+module dircolors;
+
+import std.stdio;
+import std.file : readText;
+import std.string : splitLines, strip, join;
+import std.algorithm : filter, map;
+
+immutable string defaultDB = q"EOF"
+# Default color database
+DIR 01;34
+LINK 01;36
+FIFO 40;33
+SOCK 01;35
+BLK 40;33;01
+CHR 40;33;01
+ORPHAN 40;31;01
+EXEC 01;32
+EOF";
+
+string loadDB(string name)
+{
+    if(name.length) {
+        try { return readText(name); } catch(Exception) {}
+    }
+    return defaultDB;
+}
+
+void dircolorsCommand(string[] tokens)
+{
+    bool printDB = false;
+    string fileName;
+    string shellType = "sh";
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-b" || t == "--sh" || t == "--bourne-shell") shellType = "sh";
+        else if(t == "-c" || t == "--csh" || t == "--c-shell") shellType = "csh";
+        else if(t == "-p" || t == "--print-database") printDB = true;
+        else if(t == "--") { idx++; break; }
+        else { idx++; break; }
+        idx++;
+    }
+    if(idx < tokens.length)
+        fileName = tokens[idx];
+
+    auto db = loadDB(fileName);
+    if(printDB) {
+        writeln(db);
+        return;
+    }
+    auto entries = db.splitLines
+        .map!(l => l.strip)
+        .filter!(l => l.length && l[0] != '#')
+        .join(":");
+    if(shellType == "csh")
+        writeln("setenv LS_COLORS \"" ~ entries ~ "\"");
+    else
+        writeln("LS_COLORS=\"" ~ entries ~ "\"; export LS_COLORS");
+}
+

--- a/src/dirname.d
+++ b/src/dirname.d
@@ -1,0 +1,18 @@
+module dirname;
+
+import std.stdio;
+import std.path : dirName;
+
+void dirnameCommand(string[] tokens)
+{
+    if(tokens.length < 2) {
+        writeln("Usage: dirname path");
+        return;
+    }
+    auto path = tokens[1];
+    auto dir = dirName(path);
+    if(dir.length == 0)
+        dir = ".";
+    writeln(dir);
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -16,6 +16,9 @@ import std.datetime : Clock, SysTime;
 import core.time : dur;
 import base32;
 import base64;
+import dirname;
+import dir;
+import dircolors;
 import bc;
 import dc;
 import dd;
@@ -381,6 +384,10 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         foreach(entry; dirEntries(path, SpanMode.shallow)) {
             writeln(entry.name);
         }
+    } else if(op == "dir") {
+        dir.dirCommand(tokens);
+    } else if(op == "dircolors") {
+        dircolors.dircolorsCommand(tokens);
     } else if(op == "cat") {
         bool showEnds = false;
         bool number = false;
@@ -608,6 +615,17 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 base = base[0 .. $ - suf.length];
         }
         writeln(base);
+    } else if(op == "dirname") {
+        if(tokens.length < 2) {
+            writeln("dirname: missing operand");
+            return;
+        }
+        auto path = tokens[1];
+        auto dir = std.path.dirName(path);
+        if(dir.length == 0) dir = ".";
+        writeln(dir);
+    }
+    
     } else if(op == "animal_case") {
         string animal;
         if(tokens.length >= 2) {


### PR DESCRIPTION
## Summary
- implement `dirname`, `dir`, and `dircolors` commands
- hook the new commands into the interpreter

## Testing
- `dmd --version 2>/dev/null | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_685f000c54808327bf7531341e8cbb49