### PR TITLE
Add dmesg command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The interpreter now supports a broader set of commands:
 - `dd` to copy and convert data in blocks
 - `ddrescue` for data recovery from damaged disks
 - `df` to display free disk space
+- `dmesg` to print kernel messages
 - manage service runlevels with `chkconfig`
 - `caller` to display the current call stack frame
 

--- a/src/dmesg.d
+++ b/src/dmesg.d
@@ -1,0 +1,16 @@
+module dmesg;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system dmesg command with the provided arguments.
+void dmesgCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "dmesg" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("dmesg failed with code ", rc);
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -24,6 +24,7 @@ import dc;
 import dd;
 import ddrescue;
 import df;
+import dmesg;
 import cal;
 import chkconfig;
 import cksum;
@@ -274,6 +275,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         ddrescueCommand(tokens);
     } else if(op == "df") {
         dfCommand(tokens);
+    } else if(op == "dmesg") {
+        dmesgCommand(tokens);
     } else if(op == "for") {
         if(tokens.length < 3) {
             writeln("Usage: for start..end command");


### PR DESCRIPTION
## Summary
- implement `dmesgCommand` module
- wire `dmesg` into interpreter
- document `dmesg` in README

## Testing
- `dmd --version 2>&1 | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0652371083279aeb270545cf904e