### PR TITLE
Add eject command wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The interpreter now supports a broader set of commands:
 - `ddrescue` for data recovery from damaged disks
 - `df` to display free disk space
 - `dmesg` to print kernel messages
+- `eject` to eject removable media
 - manage service runlevels with `chkconfig`
 - `caller` to display the current call stack frame
 

--- a/src/eject.d
+++ b/src/eject.d
@@ -1,0 +1,15 @@
+module eject;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system eject command with the provided arguments.
+void ejectCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "eject" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("eject failed with code ", rc);
+}

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -40,6 +40,7 @@ import cut;
 import date;
 import dos2unix;
 import egrep;
+import eject;
 
 string[] history;
 string[string] aliases;
@@ -586,6 +587,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         }
     } else if(op == "egrep") {
         egrep.egrepCommand(tokens);
+    } else if(op == "eject") {
+        eject.ejectCommand(tokens);
     } else if(op == "awk") {
         if(tokens.length < 2) {
             writeln("awk program [file...]");


### PR DESCRIPTION
## Summary
- add a simple `eject` command module that forwards to the system command
- integrate `eject` into the interpreter command dispatcher
- mention `eject` in README list of supported commands

## Testing
- `git status --short`
- *No tests or build tools available*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685f0ccc41988327be8de3c992f15386