### PR TITLE
Add exit builtin to interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The interpreter now supports a broader set of commands:
 - `eject` to eject removable media
 - manage service runlevels with `chkconfig`
 - `caller` to display the current call stack frame
+- `exit` to terminate the shell with an optional status code
 
 Running the interpreter with no command argument starts an interactive shell.
 You can customize the prompt text using the `PS1` environment variable and its color with `PS_COLOR` (e.g. `PS_COLOR=green`). Type `exit` to leave the shell.

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -67,7 +67,7 @@ string[] builtinNames = [
     "chmod", "chown", "chpasswd", "chroot", "cksum", "cmp", "comm", "command",
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
-    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "for", "grep", "head",
+    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "for", "grep", "head",
     "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
     "rmdir", "tail", "touch", "unalias"
 ];
@@ -687,6 +687,17 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             import core.stdc.stdlib : exit;
             exit(rc);
         }
+    } else if(op == "exit") {
+        int code = 0;
+        if(tokens.length > 1) {
+            try {
+                code = to!int(tokens[1]);
+            } catch(Exception) {
+                // ignore invalid argument
+            }
+        }
+        import core.stdc.stdlib : exit;
+        exit(code);
     } else if(op == "awk") {
         if(tokens.length < 2) {
             writeln("awk program [file...]");


### PR DESCRIPTION
## Summary
- support `exit` builtin in interpreter
- document the new builtin in README

## Testing
- `ldc2 src/interpreter.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f15f9f574832785ea532fb6c038a3