### PR TITLE
Add expand command

### DIFF
--- a/src/expand.d
+++ b/src/expand.d
@@ -1,0 +1,94 @@
+module expand;
+
+import std.stdio;
+import std.file : readText;
+import std.string : split, replace, splitLines;
+import std.conv : to;
+import std.array : appender, Appender;
+import std.ascii : isDigit;
+
+int[] parseStops(string spec) {
+    spec = replace(spec, ",", " ");
+    int[] stops;
+    foreach(part; spec.split()) {
+        try { stops ~= to!int(part); } catch(Exception) {}
+    }
+    return stops;
+}
+
+int spacesFor(size_t col, int[] stops) {
+    if(stops.length <= 1) {
+        int width = stops.length ? stops[0] : 8;
+        return width - cast(int)(col % width);
+    }
+    foreach(s; stops) {
+        if(col < s) return s - cast(int)col;
+    }
+    return 1;
+}
+
+string expandLine(string line, int[] stops, bool initialOnly) {
+    auto out = appender!string();
+    size_t col = 0;
+    bool initial = true;
+    foreach(ch; line) {
+        if(ch == '\b') {
+            out.put(ch);
+            if(col > 0) col--; 
+            continue;
+        }
+        if(ch == '\t') {
+            if(initialOnly && !initial) {
+                out.put(ch);
+            } else {
+                int n = spacesFor(col, stops);
+                foreach(i; 0 .. n) out.put(' ');
+                col += n;
+            }
+        } else {
+            out.put(ch);
+            col++;
+            if(ch != ' ' && ch != '\t') initial = false;
+        }
+    }
+    return out.data;
+}
+
+void expandFile(string name, int[] stops, bool initialOnly) {
+    if(name == "-") {
+        foreach(line; stdin.byLine())
+            writeln(expandLine(line.idup, stops, initialOnly));
+    } else {
+        try {
+            foreach(line; readText(name).splitLines)
+                writeln(expandLine(line, stops, initialOnly));
+        } catch(Exception) {
+            writeln("expand: cannot read ", name);
+        }
+    }
+}
+
+void expandCommand(string[] tokens) {
+    bool initial = false;
+    int[] stops;
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-i" || t == "--initial") {
+            initial = true;
+        } else if(t.startsWith("-t")) {
+            string s = t.length > 2 ? t[2..$] : (idx+1 < tokens.length ? tokens[++idx] : "");
+            if(s.length) stops = parseStops(s);
+        } else if(t.startsWith("--tabs=")) {
+            stops = parseStops(t[7..$]);
+        } else if(t.length > 1 && t[1].isDigit) {
+            stops = parseStops(t[1..$]);
+        } else if(t == "--") { idx++; break; } else { break; }
+        idx++;
+    }
+    if(stops.length == 0) stops = [8];
+    auto files = tokens[idx .. $];
+    if(files.length == 0) files = ["-"];
+    foreach(f; files) expandFile(f, stops, initial);
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -41,6 +41,7 @@ import date;
 import dos2unix;
 import egrep;
 import eject;
+import expand;
 
 string[] history;
 string[string] aliases;
@@ -67,7 +68,7 @@ string[] builtinNames = [
     "chmod", "chown", "chpasswd", "chroot", "cksum", "cmp", "comm", "command",
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
-    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "for", "grep", "head",
+    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "for", "grep", "head",
     "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
     "rmdir", "tail", "touch", "unalias"
 ];
@@ -698,6 +699,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         }
         import core.stdc.stdlib : exit;
         exit(code);
+    } else if(op == "expand") {
+        expand.expandCommand(tokens);
     } else if(op == "awk") {
         if(tokens.length < 2) {
             writeln("awk program [file...]");


### PR DESCRIPTION
## Summary
- implement `expand` utility in `src/expand.d`
- register the command with the interpreter
- handle `expand` in the built‑in command list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f17e9b2788327a1890bc572a29c13