### PR TITLE
Add fdformat builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The interpreter now supports a broader set of commands:
 - compression utilities with `bzip2`
 - `dd` to copy and convert data in blocks
 - `ddrescue` for data recovery from damaged disks
+- `fdformat` to low-level format a floppy disk
 - `df` to display free disk space
 - `dmesg` to print kernel messages
 - `eject` to eject removable media

--- a/src/fdformat.d
+++ b/src/fdformat.d
@@ -1,0 +1,19 @@
+module fdformat;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system fdformat command with the provided arguments.
+void fdformatCommand(string[] tokens)
+{
+    if(tokens.length < 2) {
+        writeln("Usage: fdformat [-n] device");
+        return;
+    }
+    string args = tokens[1 .. $].join(" ");
+    string cmd = "fdformat" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("fdformat failed with code ", rc);
+}

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -24,6 +24,7 @@ import dc;
 import expr;
 import dd;
 import ddrescue;
+import fdformat;
 import df;
 import du;
 import dmesg;
@@ -67,7 +68,7 @@ string[] builtinNames = [
     "bind", "break", "builtin", "bunzip2", "bzcat", "bzip2", "bzip2recover",
     "cal", "caller", "cat", "cd", "cfdisk", "chattr", "chgrp", "chkconfig",
     "chmod", "chown", "chpasswd", "chroot", "cksum", "cmp", "comm", "command",
-    "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue",
+    "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue", "fdformat",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
     "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "grep", "head",
     "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
@@ -300,6 +301,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         ddCommand(tokens);
     } else if(op == "ddrescue") {
         ddrescueCommand(tokens);
+    } else if(op == "fdformat") {
+        fdformatCommand(tokens);
     } else if(op == "df") {
         dfCommand(tokens);
     } else if(op == "du") {


### PR DESCRIPTION
## Summary
- implement `fdformat` builtin in the shell
- document `fdformat` in README

## Testing
- `ldc2 src/interpreter.d src/base32.d src/base64.d src/dirname.d src/dir.d src/dircolors.d src/bc.d src/dc.d src/expr.d src/dd.d src/ddrescue.d src/fdformat.d src/df.d src/du.d src/dmesg.d src/cal.d src/chkconfig.d src/cksum.d src/cmp.d src/diff.d src/diff3.d src/comm.d src/cron.d src/crontab.d src/csplit.d src/cut.d src/date.d src/dos2unix.d src/egrep.d src/eject.d src/expand.d -of=interpreter_test` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f20af05908327a73c345de2e6d907