### PR TITLE
Add fg builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The interpreter now supports a broader set of commands:
 - Haskell-style `for` loops, e.g. `for 1..3 echo hi`
 - concurrent commands using `&`, e.g. `echo one & echo two`
 - `bg` to run a command in the background or resume a stopped job
+- `fg` to bring a background job to the foreground
 - `jobs` to list background jobs
 - sequential commands separated by `;`
 - file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, `chattr`, and `chown`


### PR DESCRIPTION
## Summary
- implement `fg` builtin for bringing background jobs to the foreground
- list `fg` in available builtins
- document `fg` in the README

## Testing
- `ldc2 src/interpreter.d src/base32.d src/base64.d src/dirname.d src/dir.d src/dircolors.d src/bc.d src/dc.d src/expr.d src/dd.d src/ddrescue.d src/fdformat.d src/fdisk.d src/df.d src/du.d src/dmesg.d src/cal.d src/chkconfig.d src/cksum.d src/cmp.d src/diff.d src/diff3.d src/comm.d src/cron.d src/crontab.d src/csplit.d src/cut.d src/date.d src/dos2unix.d src/egrep.d src/eject.d src/expand.d -of=interpreter` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2646cc388327af56d28e9e6593c8