### PR TITLE
Add fgrep command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The interpreter now supports a broader set of commands:
 - `jobs` to list background jobs
 - sequential commands separated by `;`
 - file utilities such as `cp`, `mv`, `rm`, `mkdir`, `rmdir`, `touch`, `chattr`, and `chown`
-- text display commands like `cat`, `head`, `tail`, and `grep`
+ - text display commands like `cat`, `head`, `tail`, `grep`, and `fgrep`
 - `date` for the current time
  - schedule commands using `at`
  - run recurring scheduled jobs with `cron`

--- a/src/fgrep.d
+++ b/src/fgrep.d
@@ -1,0 +1,78 @@
+module fgrep;
+
+import std.stdio;
+import std.file : readText;
+import std.algorithm.searching : canFind;
+import std.string : toLower;
+import std.conv : to;
+
+void fgrepCommand(string[] tokens)
+{
+    bool countOnly = false;
+    bool silent = false;
+    bool invert = false;
+    bool ignoreCase = false;
+    bool listOnly = false;
+    string pattern;
+
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-c") countOnly = true;
+        else if(t == "-s") silent = true;
+        else if(t == "-v") invert = true;
+        else if(t == "-i") ignoreCase = true;
+        else if(t == "-l") listOnly = true;
+        else if(t == "-e") {
+            idx++;
+            if(idx < tokens.length) pattern = tokens[idx];
+            else {
+                if(!silent) writeln("fgrep: option requires an argument -- e");
+                return;
+            }
+        } else {
+            break;
+        }
+        idx++;
+    }
+
+    if(pattern.length == 0 && idx < tokens.length) {
+        pattern = tokens[idx];
+        idx++;
+    }
+
+    if(pattern.length == 0 || idx >= tokens.length) {
+        if(!silent) writeln("Usage: fgrep [OPTIONS] pattern file...");
+        return;
+    }
+
+    auto files = tokens[idx .. $];
+    auto pat = ignoreCase ? pattern.toLower : pattern;
+    foreach(f; files) {
+        size_t count = 0;
+        try {
+            foreach(line; readText(f).splitLines) {
+                auto l = ignoreCase ? line.toLower : line;
+                bool matched = l.canFind(pat);
+                if(invert) matched = !matched;
+                if(matched) {
+                    count++;
+                    if(!countOnly && !silent && !listOnly) {
+                        if(files.length > 1) write(f ~ ":");
+                        writeln(line);
+                    }
+                }
+            }
+            if(listOnly && count > 0 && !silent)
+                writeln(f);
+            if(countOnly && !silent)
+                if(files.length > 1)
+                    writeln(f ~ ":" ~ to!string(count));
+                else
+                    writeln(to!string(count));
+        } catch(Exception) {
+            if(!silent) writeln("fgrep: cannot read ", f);
+        }
+    }
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -19,6 +19,7 @@ import base64;
 import dirname;
 import dir;
 import dircolors;
+import fgrep;
 import bc;
 import dc;
 import expr;
@@ -71,7 +72,7 @@ string[] builtinNames = [
     "chmod", "chown", "chpasswd", "chroot", "cksum", "cmp", "comm", "command",
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue", "fdformat", "fdisk",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
-    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "grep", "head",
+    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "grep", "fgrep", "head",
     "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
     "rmdir", "tail", "touch", "unalias"
 ];
@@ -615,6 +616,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 writeln("grep: cannot read ", f);
             }
         }
+    } else if(op == "fgrep") {
+        fgrep.fgrepCommand(tokens);
     } else if(op == "egrep") {
         egrep.egrepCommand(tokens);
     } else if(op == "eject") {


### PR DESCRIPTION
## Summary
- add `fgrep` command module
- wire `fgrep` into the interpreter
- document `fgrep` support in README

## Testing
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f273d87748327876fe673b9595567