### PR TITLE
Add simple find command

### DIFF
--- a/src/find.d
+++ b/src/find.d
@@ -1,0 +1,75 @@
+module find;
+
+import std.stdio;
+import std.file : dirEntries, SpanMode, isFile, isDir;
+import std.path : baseName, buildPath;
+import std.algorithm : canFind;
+import std.path : globMatch;
+import std.conv : to;
+
+void search(string path, string pattern, bool usePattern, char ftype, int depth, int maxDepth)
+{
+    foreach(entry; dirEntries(path, SpanMode.shallow))
+    {
+        string name = entry.name;
+        // match base name against pattern if provided
+        bool match = true;
+        if(usePattern)
+            match = globMatch(baseName(name), pattern);
+        if(match && ftype)
+        {
+            if(ftype == 'f' && !entry.isFile)
+                match = false;
+            else if(ftype == 'd' && !entry.isDir)
+                match = false;
+        }
+        if(match)
+            writeln(name);
+        // recurse into directories
+        if(entry.isDir && (maxDepth < 0 || depth < maxDepth))
+            search(name, pattern, usePattern, ftype, depth+1, maxDepth);
+    }
+}
+
+/// Very small subset of GNU find supporting -name, -type and -maxdepth
+void findCommand(string[] tokens)
+{
+    string start = ".";
+    string pattern;
+    bool usePattern = false;
+    char ftype = '\0';
+    int maxDepth = -1; // unlimited
+
+    size_t idx = 1;
+    if(idx < tokens.length && !tokens[idx].startsWith("-"))
+    {
+        start = tokens[idx];
+        idx++;
+    }
+    while(idx < tokens.length)
+    {
+        auto t = tokens[idx];
+        if(t == "-name" && idx + 1 < tokens.length)
+        {
+            pattern = tokens[idx+1];
+            usePattern = true;
+            idx += 2;
+        }
+        else if(t == "-type" && idx + 1 < tokens.length)
+        {
+            ftype = tokens[idx+1][0];
+            idx += 2;
+        }
+        else if(t == "-maxdepth" && idx + 1 < tokens.length)
+        {
+            maxDepth = to!int(tokens[idx+1]);
+            idx += 2;
+        }
+        else
+        {
+            idx++;
+        }
+    }
+    search(start, pattern, usePattern, ftype, 0, maxDepth);
+}
+

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -20,6 +20,7 @@ import dirname;
 import dir;
 import dircolors;
 import fgrep;
+import find;
 import bc;
 import dc;
 import expr;
@@ -73,7 +74,7 @@ string[] builtinNames = [
     "chmod", "chown", "chpasswd", "chroot", "cksum", "cmp", "comm", "command",
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue", "fdformat", "fdisk",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
-    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "grep", "fgrep", "file", "head",
+    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "grep", "fgrep", "file", "find", "head",
     "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
     "rmdir", "tail", "touch", "unalias"
 ];
@@ -623,6 +624,8 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         egrep.egrepCommand(tokens);
     } else if(op == "file") {
         file.fileCommand(tokens);
+    } else if(op == "find") {
+        find.findCommand(tokens);
     } else if(op == "eject") {
         eject.ejectCommand(tokens);
     } else if(op == "env") {


### PR DESCRIPTION
## Summary
- implement a minimal `find` command that supports `-name`, `-type` and `-maxdepth`
- wire new command into the interpreter and builtin list

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_685f29e272cc8327a9793475f7a47e16