### PR TITLE
Add fuser, awk, and getopts commands

### DIFF
--- a/src/awk.d
+++ b/src/awk.d
@@ -1,0 +1,76 @@
+module awk;
+
+import std.stdio;
+import std.file : readText;
+import std.regex : regex, matchFirst;
+import std.string : split, stripRight;
+import std.conv : to;
+
+/// Minimal awk implementation supporting simple print statements.
+void awkCommand(string[] tokens)
+{
+    if(tokens.length < 2) {
+        writeln("awk program [file...]");
+        return;
+    }
+
+    string fs = " ";
+    size_t idx = 1;
+    if(idx + 1 < tokens.length && tokens[idx] == "-F") {
+        fs = tokens[idx + 1];
+        idx += 2;
+    }
+    if(idx >= tokens.length) {
+        writeln("awk: missing program");
+        return;
+    }
+
+    auto program = tokens[idx];
+    idx++;
+    auto files = tokens[idx .. $];
+
+    if(program.length >= 2 &&
+       ((program[0] == '\'' && program[$-1] == '\'') ||
+        (program[0] == '"' && program[$-1] == '"')))
+        program = program[1 .. $-1];
+
+    auto re = regex(`^\s*(?:(.*?)\s+)?\{\s*print\s*(\$[0-9]+)?\s*\}\s*$`);
+    auto m = matchFirst(program, re);
+    if(m.empty) {
+        writeln("awk: unsupported program");
+        return;
+    }
+    string pattern = m.captures[1];
+    string fieldStr = m.captures[2];
+    int fieldIdx = 0;
+    if(fieldStr.length)
+        fieldIdx = to!int(fieldStr[1 .. $]);
+
+    string[] inputLines;
+    if(files.length == 0) {
+        string line;
+        while((line = readln()) !is null) {
+            inputLines ~= line.stripRight;
+        }
+    } else {
+        foreach(f; files) {
+            try {
+                inputLines ~= readText(f).splitLines;
+            } catch(Exception e) {
+                writeln("awk: cannot read ", f);
+            }
+        }
+    }
+
+    foreach(line; inputLines) {
+        auto l = line;
+        if(pattern.length == 0 || l.canFind(pattern)) {
+            auto fields = l.split(fs);
+            if(fieldIdx == 0)
+                writeln(l);
+            else if(fieldIdx <= cast(int)fields.length)
+                writeln(fields[fieldIdx - 1]);
+        }
+    }
+}
+

--- a/src/fuser.d
+++ b/src/fuser.d
@@ -1,0 +1,75 @@
+module fuser;
+
+import std.stdio;
+import std.file : dirEntries, readLink, exists;
+import std.path : baseName, buildPath;
+import core.sys.posix.signal : kill, SIGKILL;
+import std.conv : to;
+import core.sys.posix.unistd : getpid;
+
+/// List processes using a given file. Supports -k to kill them.
+void fuserCommand(string[] tokens)
+{
+    bool killProcs = false;
+    bool interactive = false;
+    string target;
+
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-k") killProcs = true;
+        else if(t == "-i") interactive = true;
+        else {
+            break;
+        }
+        idx++;
+    }
+    if(idx < tokens.length) target = tokens[idx];
+    if(target.length == 0) {
+        writeln("Usage: fuser [-k] [-i] file");
+        return;
+    }
+    if(!exists(target)) {
+        writeln("fuser: file not found: ", target);
+        return;
+    }
+    string[] pids;
+    foreach(entry; dirEntries("/proc", SpanMode.shallow)) {
+        auto name = baseName(entry.name);
+        bool isNum = true;
+        foreach(ch; name) {
+            if(ch < '0' || ch > '9') { isNum = false; break; }
+        }
+        if(!isNum) continue;
+        auto pid = name;
+        auto fdPath = buildPath(entry.name, "fd");
+        foreach(fd; dirEntries(fdPath, SpanMode.shallow)) {
+            try {
+                auto link = readLink(fd.name);
+                if(link == target) {
+                    pids ~= pid;
+                    break;
+                }
+            } catch(Exception) {}
+        }
+    }
+
+    if(pids.length == 0) return;
+    foreach(pid; pids) {
+        write(pid ~ " ");
+        if(killProcs) {
+            bool doKill = true;
+            if(interactive) {
+                write("Kill process " ~ pid ~ "? [y/N] ");
+                auto resp = readln();
+                if(resp is null || resp.strip.toLower != "y")
+                    doKill = false;
+            }
+            if(doKill) {
+                kill(to!int(pid), SIGKILL);
+            }
+        }
+    }
+    writeln();
+}
+

--- a/src/getopts.d
+++ b/src/getopts.d
@@ -1,0 +1,74 @@
+module getopts;
+
+import std.stdio;
+import std.string : strip;
+import std.conv : to;
+
+extern __gshared string[string] variables; // from interpreter
+
+/// Simplified getopts implementation.
+void getoptsCommand(string[] tokens)
+{
+    if(tokens.length < 3) {
+        writeln("Usage: getopts optstring name [args]");
+        return;
+    }
+    auto optstring = tokens[1];
+    auto name = tokens[2];
+    string[] args = tokens.length > 3 ? tokens[3 .. $] : [];
+
+    size_t optind = 1;
+    if("OPTIND" in variables) {
+        try optind = to!size_t(variables["OPTIND"]); catch(Exception) {}
+    }
+
+    if(optind == 0) optind = 1;
+    if(optind > args.length) {
+        variables[name] = "?";
+        return;
+    }
+
+    auto arg = args[optind - 1];
+    if(arg.length < 2 || arg[0] != '-' || arg == "-") {
+        variables[name] = "?";
+        return;
+    }
+    if(arg == "--") {
+        optind++;
+        variables[name] = "?";
+        variables["OPTIND"] = to!string(optind);
+        return;
+    }
+    char opt = arg[1];
+    bool expectArg = false;
+    auto pos = optstring.indexOf(opt);
+    if(pos == -1) {
+        variables[name] = "?";
+        variables["OPTARG"] = opt;
+        optind++;
+        variables["OPTIND"] = to!string(optind);
+        return;
+    }
+    if(pos + 1 < optstring.length && optstring[pos+1] == ':')
+        expectArg = true;
+
+    string optarg;
+    if(expectArg) {
+        if(arg.length > 2) {
+            optarg = arg[2 .. $];
+        } else if(optind < args.length) {
+            optind++;
+            optarg = args[optind - 1];
+        } else {
+            variables[name] = expectArg ? ":" : "?";
+            variables["OPTIND"] = to!string(optind);
+            return;
+        }
+    }
+
+    optind++;
+    variables[name] = to!string(opt);
+    variables["OPTIND"] = to!string(optind);
+    if(expectArg) variables["OPTARG"] = optarg; else variables.remove("OPTARG");
+}
+


### PR DESCRIPTION
## Summary
- implement `awk` command logic in a new module
- add a simple `fuser` utility
- implement `getopts` builtin with OPTIND/OPTARG handling
- expose variables globally and wire new commands into the interpreter

## Testing
- `dmd -i -c src/interpreter.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2e1eef4c8327b970e69b971e99ed