### PR TITLE
Add basic ACL and group commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The interpreter now supports a broader set of commands:
 - `dmesg` to print kernel messages
 - `fold` to wrap text to a fixed width
 - `fsck` to check and repair filesystems
+- `getfacl` to display file access control lists
+- `groupadd` to create new groups
+- `groupdel` to delete groups
 - `eject` to eject removable media
 - manage service runlevels with `chkconfig`
 - `caller` to display the current call stack frame

--- a/src/getfacl.d
+++ b/src/getfacl.d
@@ -1,0 +1,15 @@
+module getfacl;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system getfacl command with the provided arguments.
+void getfaclCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "getfacl" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("getfacl failed with code ", rc);
+}

--- a/src/groupadd.d
+++ b/src/groupadd.d
@@ -1,0 +1,15 @@
+module groupadd;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system groupadd command with the provided arguments.
+void groupaddCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "groupadd" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("groupadd failed with code ", rc);
+}

--- a/src/groupdel.d
+++ b/src/groupdel.d
@@ -1,0 +1,15 @@
+module groupdel;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system groupdel command with the provided arguments.
+void groupdelCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "groupdel" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("groupdel failed with code ", rc);
+}

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -54,6 +54,9 @@ import fsck;
 import awk;
 import fuser;
 import getopts;
+import getfacl;
+import groupadd;
+import groupdel;
 
 string[] history;
 string[string] aliases;
@@ -80,7 +83,7 @@ string[] builtinNames = [
     "chmod", "chown", "chpasswd", "chroot", "cksum", "cmp", "comm", "command",
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue", "fdformat", "fdisk",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
-    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "getopts", "grep", "fgrep", "file", "find", "fmt", "fold", "fsck", "fuser", "head",
+    "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "getopts", "grep", "fgrep", "file", "find", "fmt", "fold", "fsck", "fuser", "getfacl", "groupadd", "groupdel", "head",
     "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
     "rmdir", "tail", "touch", "unalias"
 ];
@@ -640,6 +643,12 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         fsck.fsckCommand(tokens);
     } else if(op == "fuser") {
         fuser.fuserCommand(tokens);
+    } else if(op == "getfacl") {
+        getfacl.getfaclCommand(tokens);
+    } else if(op == "groupadd") {
+        groupadd.groupaddCommand(tokens);
+    } else if(op == "groupdel") {
+        groupdel.groupdelCommand(tokens);
     } else if(op == "eject") {
         eject.ejectCommand(tokens);
     } else if(op == "env") {


### PR DESCRIPTION
## Summary
- add `getfacl`, `groupadd`, and `groupdel` wrappers
- hook new commands into interpreter
- document the new commands

## Testing
- `ldc2 -of=interpreter src/*.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3046aed48327892286138365a556