### PR TITLE
Add groupmod, groups, gzip and hash builtins

### DIFF
--- a/src/groupmod.d
+++ b/src/groupmod.d
@@ -1,0 +1,15 @@
+module groupmod;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system groupmod command with the provided arguments.
+void groupmodCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "groupmod" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("groupmod failed with code ", rc);
+}

--- a/src/groups.d
+++ b/src/groups.d
@@ -1,0 +1,15 @@
+module groups;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system groups command with the provided arguments.
+void groupsCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "groups" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("groups failed with code ", rc);
+}

--- a/src/gzip.d
+++ b/src/gzip.d
@@ -1,0 +1,15 @@
+module gzip;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system gzip command with the provided arguments.
+void gzipCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "gzip" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("gzip failed with code ", rc);
+}


### PR DESCRIPTION
## Summary
- implement `groupmod`, `groups` and `gzip` wrappers
- add a `hash` builtin that caches command locations
- record cached command paths and search `$PATH` when executing

## Testing
- `ldc2 -c src/interpreter.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f31de4c2483278e919e70347227d1