### PR TITLE
Add iconv, id, if, ifconfig commands

### DIFF
--- a/src/iconv.d
+++ b/src/iconv.d
@@ -1,0 +1,15 @@
+module iconv;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system iconv command with the provided arguments.
+void iconvCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "iconv" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("iconv failed with code ", rc);
+}

--- a/src/id.d
+++ b/src/id.d
@@ -1,0 +1,15 @@
+module id;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system id command with the provided arguments.
+void idCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "id" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("id failed with code ", rc);
+}

--- a/src/ifcmd.d
+++ b/src/ifcmd.d
@@ -1,0 +1,20 @@
+module ifcmd;
+
+import std.stdio;
+import std.string : join, replace;
+import std.process : system;
+
+/// Evaluate a shell if statement using /bin/sh.
+void ifCommand(string[] tokens)
+{
+    if(tokens.length < 2) {
+        writeln("if: missing condition");
+        return;
+    }
+    string script = "if " ~ tokens[1 .. $].join(" ");
+    string escaped = script.replace("\"", "\\\"");
+    string cmd = "sh -c \"" ~ escaped ~ "\"";
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("if command failed with code ", rc);
+}

--- a/src/ifconfig.d
+++ b/src/ifconfig.d
@@ -1,0 +1,15 @@
+module ifconfig;
+
+import std.stdio;
+import std.string : join;
+import std.process : system;
+
+/// Execute the system ifconfig command with the provided arguments.
+void ifconfigCommand(string[] tokens)
+{
+    string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
+    string cmd = "ifconfig" ~ (args.length ? " " ~ args : "");
+    auto rc = system(cmd);
+    if(rc != 0)
+        writeln("ifconfig failed with code ", rc);
+}

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -60,6 +60,10 @@ import groupdel;
 import groupmod;
 import groups;
 import gzip;
+import iconv;
+import id;
+import ifcmd;
+import ifconfig;
 
 string[] history;
 string[string] aliases;
@@ -88,7 +92,7 @@ string[] builtinNames = [
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue", "fdformat", "fdisk",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
     "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "getopts", "grep", "fgrep", "file", "find", "fmt", "fold", "fsck", "fuser", "getfacl", "groupadd", "groupdel", "groupmod", "groups", "gzip", "hash", "head",
-    "help", "history", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
+    "help", "history", "iconv", "id", "if", "ifconfig", "jobs", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
     "rmdir", "tail", "touch", "unalias"
 ];
 
@@ -1743,6 +1747,14 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         foreach(i, cmdLine; history) {
             writeln(i + 1, " ", cmdLine);
         }
+    } else if(op == "iconv") {
+        iconv.iconvCommand(tokens);
+    } else if(op == "id") {
+        id.idCommand(tokens);
+    } else if(op == "if") {
+        ifcmd.ifCommand(tokens);
+    } else if(op == "ifconfig") {
+        ifconfig.ifconfigCommand(tokens);
     } else if(op == "jobs") {
         foreach(job; bgJobs) {
             auto status = job.running ? "Running" : "Done";


### PR DESCRIPTION
## Summary
- wrap iconv command
- wrap id command
- wrap ifconfig command
- implement simple `if` via /bin/sh
- expose new commands to the interpreter

## Testing
- `ldc2 src/*.d -of=interpreter >/tmp/build.log && tail -n 20 /tmp/build.log` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3585c33c8327898169dc6bfc2060