### PR TITLE
Add local and login related builtins

### DIFF
--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -78,6 +78,11 @@ import less;
 import letcmd;
 import linkcmd;
 import ln;
+import local;
+import locate;
+import login;
+import logname;
+import logout;
 
 string[] history;
 string[string] aliases;
@@ -107,7 +112,7 @@ string[] builtinNames = [
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
     "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "getopts", "grep", "fgrep", "file", "find", "fmt", "fold", "fsck", "fuser", "getfacl", "groupadd", "groupdel", "groupmod", "groups", "gzip", "hash", "head",
     "help", "history", "iconv", "id", "if", "ifconfig", "ifdown", "ifup", "import", "install", "iostat", "ip", "jobs", "join", "kill", "killall", "klist", "less", "let", "link", "ln", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
-    "rmdir", "tail", "touch", "unalias"
+    "rmdir", "tail", "touch", "unalias", "local", "locate", "login", "logname", "logout"
 ];
 
 bool[string] builtinEnabled;
@@ -1802,6 +1807,16 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         linkcmd.linkCommand(tokens);
     } else if(op == "ln") {
         ln.lnCommand(tokens);
+    } else if(op == "local") {
+        local.localCommand(tokens);
+    } else if(op == "locate") {
+        locate.locateCommand(tokens);
+    } else if(op == "login") {
+        login.loginCommand(tokens);
+    } else if(op == "logname") {
+        logname.lognameCommand(tokens);
+    } else if(op == "logout") {
+        logout.logoutCommand(tokens);
     } else if(op == "apt" || op == "apt-get") {
         auto rc = system(cmd);
         if(rc != 0) {

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -18,6 +18,11 @@ import core.sync.condition : Condition;
 import std.process : system;
 version(Posix) import core.sys.posix.unistd : execvp;
 import objectsystem;
+import local;
+import locate;
+import login;
+import logname;
+import logout;
 
 struct Expr {
     bool isList;
@@ -1105,6 +1110,30 @@ Value evalList(Expr e) {
             writeln("cp: failed to copy ", src, " to ", dst);
             return atomVal("error");
         }
+    } else if(head == "local") {
+        string[] toks = ["local"];
+        foreach(expr; e.list[1 .. $])
+            toks ~= valueToString(evalExpr(expr));
+        local.localCommand(toks);
+        return atomVal("ok");
+    } else if(head == "locate") {
+        string[] toks = ["locate"];
+        foreach(expr; e.list[1 .. $])
+            toks ~= valueToString(evalExpr(expr));
+        locate.locateCommand(toks);
+        return atomVal("ok");
+    } else if(head == "login") {
+        string[] toks = ["login"];
+        foreach(expr; e.list[1 .. $])
+            toks ~= valueToString(evalExpr(expr));
+        login.loginCommand(toks);
+        return atomVal("ok");
+    } else if(head == "logname") {
+        logname.lognameCommand(["logname"]);
+        return atomVal("ok");
+    } else if(head == "logout") {
+        logout.logoutCommand(["logout"]);
+        return num(0); /* unreachable */
     } else if(head == "cpio-create") {
         if(e.list.length < 3) return atomVal("error");
         auto archVal = evalExpr(e.list[1]);

--- a/src/local.d
+++ b/src/local.d
@@ -1,0 +1,40 @@
+module local;
+
+import std.stdio;
+
+/// Minimal local implementation - assigns variables in the global map.
+extern (C) {
+    __gshared string[string] variables;
+}
+
+void localCommand(string[] tokens)
+{
+    if(tokens.length < 2)
+    {
+        writeln("Usage: local name [value]");
+        return;
+    }
+    for(size_t i=1;i<tokens.length;i++)
+    {
+        auto arg = tokens[i];
+        auto eq = arg.indexOf('=');
+        string name;
+        string val;
+        if(eq > 0)
+        {
+            name = arg[0 .. eq];
+            val = arg[eq+1 .. $];
+        }
+        else if(i + 1 < tokens.length)
+        {
+            name = arg;
+            val = tokens[++i];
+        }
+        else
+        {
+            name = arg;
+            val = "";
+        }
+        variables[name] = val;
+    }
+}

--- a/src/locate.d
+++ b/src/locate.d
@@ -1,0 +1,37 @@
+module locate;
+
+import std.stdio;
+import std.file : dirEntries, SpanMode;
+import std.string : indexOf;
+
+void search(string path, string pattern)
+{
+    foreach(entry; dirEntries(path, SpanMode.shallow))
+    {
+        string name = entry.name;
+        if(name.indexOf(pattern) >= 0)
+            writeln(name);
+        if(entry.isDir)
+        {
+            try
+                search(name, pattern);
+            catch(Exception) {}
+        }
+    }
+}
+
+/// Very small locate implementation searching directories recursively.
+void locateCommand(string[] tokens)
+{
+    if(tokens.length < 2)
+    {
+        writeln("Usage: locate pattern [start]");
+        return;
+    }
+    string pattern = tokens[1];
+    string start = tokens.length > 2 ? tokens[2] : "/";
+    try
+        search(start, pattern);
+    catch(Exception e)
+        writeln("locate: error searching ", start);
+}

--- a/src/login.d
+++ b/src/login.d
@@ -1,0 +1,18 @@
+module login;
+
+import std.stdio;
+import std.process : environment;
+
+/// Very simple login command that sets the LOGNAME and USER environment.
+void loginCommand(string[] tokens)
+{
+    if(tokens.length < 2)
+    {
+        writeln("login: missing username");
+        return;
+    }
+    string user = tokens[1];
+    environment["LOGNAME"] = user;
+    environment["USER"] = user;
+    writeln("logged in as " ~ user);
+}

--- a/src/logname.d
+++ b/src/logname.d
@@ -1,0 +1,15 @@
+module logname;
+
+import std.stdio;
+import std.process : environment;
+
+/// Print the current login name.
+void lognameCommand(string[] tokens)
+{
+    if("LOGNAME" in environment)
+        writeln(environment["LOGNAME"]);
+    else if("USER" in environment)
+        writeln(environment["USER"]);
+    else
+        writeln("unknown");
+}

--- a/src/logout.d
+++ b/src/logout.d
@@ -1,0 +1,18 @@
+module logout;
+
+import std.stdio;
+import std.conv : to;
+import core.stdc.stdlib : exit;
+
+/// Terminate the shell session.
+void logoutCommand(string[] tokens)
+{
+    int code = 0;
+    if(tokens.length > 1)
+    {
+        try
+            code = to!int(tokens[1]);
+        catch(Exception) {}
+    }
+    exit(code);
+}


### PR DESCRIPTION
## Summary
- implement `local`, `locate`, `login`, `logname`, and `logout` commands
- wire them into the interpreter
- expose them to the LFE REPL

## Testing
- `dmd -c src/interpreter.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f404e29fc8327ba4c61be1c2c0f7a