### PR TITLE
Implement look, lsblk, ls and lsof

### DIFF
--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -83,6 +83,10 @@ import locate;
 import login;
 import logname;
 import logout;
+import look;
+import lsblk;
+import lsof;
+import ls;
 
 string[] history;
 string[string] aliases;
@@ -111,8 +115,8 @@ string[] builtinNames = [
     "cp", "cron", "crontab", "csplit", "cut", "date", "dc", "dd", "ddrescue", "fdformat", "fdisk",
     "declare", "df", "diff", "diff3", "dir", "dircolors", "dirname", "dirs",
     "dmesg", "dos2unix", "du", "echo", "egrep", "eject", "env", "eval", "exec", "exit", "expand", "false", "expr", "export", "for", "getopts", "grep", "fgrep", "file", "find", "fmt", "fold", "fsck", "fuser", "getfacl", "groupadd", "groupdel", "groupmod", "groups", "gzip", "hash", "head",
-    "help", "history", "iconv", "id", "if", "ifconfig", "ifdown", "ifup", "import", "install", "iostat", "ip", "jobs", "join", "kill", "killall", "klist", "less", "let", "link", "ln", "ls", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
-    "rmdir", "tail", "touch", "unalias", "local", "locate", "login", "logname", "logout"
+    "help", "history", "iconv", "id", "if", "ifconfig", "ifdown", "ifup", "import", "install", "iostat", "ip", "jobs", "join", "kill", "killall", "klist", "less", "let", "link", "ln", "look", "login", "logname", "logout", "ls", "lsblk", "lsof", "mkdir", "mv", "popd", "pushd", "pwd", "rm",
+    "rmdir", "tail", "touch", "unalias", "local", "locate"
 ];
 
 bool[string] builtinEnabled;
@@ -514,10 +518,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
     } else if(op == "pwd") {
         writeln(getcwd());
     } else if(op == "ls") {
-        string path = tokens.length > 1 ? tokens[1] : ".";
-        foreach(entry; dirEntries(path, SpanMode.shallow)) {
-            writeln(entry.name);
-        }
+        ls.lsCommand(tokens);
     } else if(op == "dir") {
         dir.dirCommand(tokens);
     } else if(op == "dircolors") {
@@ -1817,6 +1818,12 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         logname.lognameCommand(tokens);
     } else if(op == "logout") {
         logout.logoutCommand(tokens);
+    } else if(op == "look") {
+        look.lookCommand(tokens);
+    } else if(op == "lsblk") {
+        lsblk.lsblkCommand(tokens);
+    } else if(op == "lsof") {
+        lsof.lsofCommand(tokens);
     } else if(op == "apt" || op == "apt-get") {
         auto rc = system(cmd);
         if(rc != 0) {

--- a/src/look.d
+++ b/src/look.d
@@ -1,0 +1,60 @@
+module look;
+
+import std.stdio;
+import std.string : toLower, strip;
+import std.file : readText, File;
+import std.algorithm : filter;
+import std.ascii : isAlphaNum;
+
+void lookCommand(string[] tokens)
+{
+    bool dict = false;
+    bool ignoreCase = false;
+    dchar term;
+    bool useTerm = false;
+
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-d") dict = true;
+        else if(t == "-f") ignoreCase = true;
+        else if(t.startsWith("-t")) {
+            if(t.length > 2)
+                term = t[2];
+            else if(idx + 1 < tokens.length)
+                term = tokens[++idx][0];
+            useTerm = true;
+        } else if(t == "--") { idx++; break; }
+        idx++;
+    }
+
+    if(idx >= tokens.length) { writeln("look: missing string"); return; }
+    string prefix = tokens[idx++];
+    string file = idx < tokens.length ? tokens[idx] : "/usr/share/dict/words";
+
+    File f;
+    try { f = File(file, "r"); } catch(Exception) { writeln("look: cannot read ", file); return; }
+
+    foreach(line; f.byLine()) {
+        auto l = line.chomp;
+        string cmpLine = l;
+        string cmpPref = prefix;
+        if(useTerm) {
+            auto p = cmpLine.indexOf(term);
+            if(p >= 0) cmpLine = cmpLine[0 .. p+1];
+            p = cmpPref.indexOf(term);
+            if(p >= 0) cmpPref = cmpPref[0 .. p+1];
+        }
+        if(dict) {
+            cmpLine = cmpLine.filter!(c => isAlphaNum(c)).idup;
+            cmpPref = cmpPref.filter!(c => isAlphaNum(c)).idup;
+        }
+        if(ignoreCase) {
+            cmpLine = toLower(cmpLine);
+            cmpPref = toLower(cmpPref);
+        }
+        if(cmpLine.startsWith(cmpPref))
+            writeln(l);
+    }
+}
+

--- a/src/ls.d
+++ b/src/ls.d
@@ -1,0 +1,67 @@
+module ls;
+
+import std.stdio;
+import std.file : dirEntries, DirEntry, SpanMode;
+import std.algorithm : sort;
+import std.string : format;
+import std.datetime : unixTimeToStdTime, SysTime;
+import core.sys.posix.sys.stat : S_IFMT, S_IFDIR, S_IFLNK, S_IFCHR, S_IFBLK, S_IFIFO, S_IFSOCK,
+    S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IWGRP, S_IXGRP, S_IROTH, S_IWOTH, S_IXOTH;
+
+string permString(uint mode)
+{
+    char type = '-';
+    switch(mode & S_IFMT) {
+        case S_IFDIR:  type = 'd'; break;
+        case S_IFLNK:  type = 'l'; break;
+        case S_IFCHR:  type = 'c'; break;
+        case S_IFBLK:  type = 'b'; break;
+        case S_IFIFO:  type = 'p'; break;
+        case S_IFSOCK: type = 's'; break;
+        default: break;
+    }
+    string out;
+    out ~= type;
+    uint[9] bits = [S_IRUSR,S_IWUSR,S_IXUSR,S_IRGRP,S_IWGRP,S_IXGRP,S_IROTH,S_IWOTH,S_IXOTH];
+    foreach(i,b; bits) {
+        if(mode & b) {
+            final switch(i%3) {
+                case 0: out ~= 'r'; break;
+                case 1: out ~= 'w'; break;
+                case 2: out ~= 'x'; break;
+            }
+        } else out ~= '-';
+    }
+    return out;
+}
+
+void lsCommand(string[] tokens)
+{
+    bool all = false;
+    bool longFmt = false;
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-a" || t == "--all") all = true;
+        else if(t == "-l") longFmt = true;
+        else if(t == "--") { idx++; break; }
+        idx++;
+    }
+    string path = idx < tokens.length ? tokens[idx] : ".";
+    DirEntry[] entries;
+    foreach(e; dirEntries(path, SpanMode.shallow)) entries ~= e;
+    entries.sort!((a,b) => a.name < b.name);
+    foreach(e; entries) {
+        auto name = e.name;
+        if(!all && name.startsWith(".")) continue;
+        if(longFmt) {
+            auto st = e.stat;
+            auto perms = permString(st.st_mode);
+            auto size = st.st_size;
+            writefln("%s %8d %s", perms, size, name);
+        } else {
+            writeln(name);
+        }
+    }
+}
+

--- a/src/lsblk.d
+++ b/src/lsblk.d
@@ -1,0 +1,54 @@
+module lsblk;
+
+import std.stdio;
+import std.file : dirEntries, readText, exists, SpanMode;
+import std.string : strip;
+import std.algorithm : sort;
+import std.conv : to;
+import df : humanSize;
+
+void lsblkCommand(string[] tokens)
+{
+    bool bytes = false;
+    bool all = false;
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t == "-b" || t == "--bytes") bytes = true;
+        else if(t == "-a" || t == "--all") all = true;
+        else if(t == "--") { idx++; break; }
+        idx++;
+    }
+
+    string[] devs;
+    foreach(entry; dirEntries("/sys/block", SpanMode.shallow))
+        devs ~= entry.name;
+    devs.sort;
+
+    writeln("NAME\tSIZE");
+    foreach(dev; devs) {
+        auto sizePath = "/sys/block/"~dev~"/size";
+        ulong sectors = 0;
+        if(exists(sizePath)) {
+            try { sectors = to!ulong(strip(readText(sizePath))); } catch(Exception) {}
+        }
+        ulong bytesTotal = sectors * 512;
+        if(bytesTotal == 0 && !all) continue;
+        string size = bytes ? to!string(bytesTotal) : humanSize(bytesTotal, false);
+        writefln("%s\t%s", dev, size);
+        foreach(part; dirEntries("/sys/block/"~dev, SpanMode.shallow)) {
+            if(part.isDir && part.name.startsWith(dev)) {
+                auto psizePath = "/sys/block/"~dev~"/"~part.name~"/size";
+                ulong psec = 0;
+                if(exists(psizePath)) {
+                    try { psec = to!ulong(strip(readText(psizePath))); } catch(Exception) {}
+                }
+                ulong pbytes = psec * 512;
+                if(pbytes == 0 && !all) continue;
+                string psize = bytes ? to!string(pbytes) : humanSize(pbytes, false);
+                writefln("`- %s\t%s", part.name, psize);
+            }
+        }
+    }
+}
+

--- a/src/lsof.d
+++ b/src/lsof.d
@@ -1,0 +1,42 @@
+module lsof;
+
+import std.stdio;
+import std.file : dirEntries, readLink, readText, SpanMode;
+import std.string : strip;
+import std.algorithm : sort;
+
+bool isNumeric(string s) {
+    foreach(ch; s) if(ch < '0' || ch > '9') return false; 
+    return s.length > 0;
+}
+
+void lsofCommand(string[] tokens)
+{
+    string pidFilter;
+    size_t idx = 1;
+    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+        auto t = tokens[idx];
+        if(t.startsWith("-p")) {
+            if(t.length > 2) pidFilter = t[2..$];
+            else if(idx + 1 < tokens.length) pidFilter = tokens[++idx];
+        } else if(t == "--") { idx++; break; }
+        idx++;
+    }
+
+    writeln("COMMAND\tPID\tFD\tNAME");
+    foreach(procDir; dirEntries("/proc", SpanMode.shallow)) {
+        if(!procDir.isDir) continue;
+        auto pid = procDir.name;
+        if(!isNumeric(pid)) continue;
+        if(pidFilter.length && pid != pidFilter) continue;
+        string comm;
+        try { comm = strip(readText("/proc/"~pid~"/comm")); } catch(Exception) { comm = pid; }
+        foreach(fdEntry; dirEntries("/proc/"~pid~"/fd", SpanMode.shallow)) {
+            string fd = fdEntry.name;
+            string target;
+            try { target = readLink("/proc/"~pid~"/fd/"~fd); } catch(Exception) { target = ""; }
+            writefln("%s\t%s\t%s\t%s", comm, pid, fd, target);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a simple implementation of `look` with basic options
- implement `lsblk` reading `/sys/block`
- implement `lsof` by walking `/proc/*/fd`
- extend `ls` command and call it from interpreter
- register new commands in the interpreter

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f4222a5cc832791e41af5ce8a1dd7