### PR TITLE
Fix interpreter build errors

### DIFF
--- a/src/base32.d
+++ b/src/base32.d
@@ -7,7 +7,7 @@ immutable string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 
 string base32Encode(const(ubyte)[] data, size_t wrap = 76)
 {
-    auto out = appender!string();
+    auto result = appender!string();
     uint buffer = 0;
     int bits = 0;
     size_t line = 0;
@@ -16,11 +16,11 @@ string base32Encode(const(ubyte)[] data, size_t wrap = 76)
         bits += 8;
         while(bits >= 5) {
             auto idx = (buffer >> (bits - 5)) & 31;
-            out.put(alphabet[idx]);
+            result.put(alphabet[idx]);
             bits -= 5;
             line++;
             if(wrap > 0 && line >= wrap) {
-                out.put('\n');
+                result.put('\n');
                 line = 0;
             }
         }
@@ -28,22 +28,22 @@ string base32Encode(const(ubyte)[] data, size_t wrap = 76)
     if(bits > 0) {
         buffer <<= (5 - bits);
         auto idx = buffer & 31;
-        out.put(alphabet[idx]);
+        result.put(alphabet[idx]);
         line++;
         if(wrap > 0 && line >= wrap) {
-            out.put('\n');
+            result.put('\n');
             line = 0;
         }
     }
     while(line % 8 != 0) {
-        out.put('=');
+        result.put('=');
         line++;
         if(wrap > 0 && line >= wrap) {
-            out.put('\n');
+            result.put('\n');
             line = 0;
         }
     }
-    return out.data;
+    return result.data;
 }
 
 ubyte[] base32Decode(string data, bool ignoreGarbage = false)
@@ -55,7 +55,7 @@ ubyte[] base32Decode(string data, bool ignoreGarbage = false)
         map[cast(ubyte)toLower(ch)] = i;
     }
 
-    auto out = appender!(ubyte[])();
+    auto result = appender!(ubyte[])();
     uint buffer = 0;
     int bits = 0;
     foreach(ch; data) {
@@ -74,9 +74,9 @@ ubyte[] base32Decode(string data, bool ignoreGarbage = false)
         bits += 5;
         if(bits >= 8) {
             auto byte = (buffer >> (bits - 8)) & 0xFF;
-            out.put(cast(ubyte)byte);
+            result.put(cast(ubyte)byte);
             bits -= 8;
         }
     }
-    return out.data;
+    return result.data;
 }

--- a/src/base64.d
+++ b/src/base64.d
@@ -7,7 +7,7 @@ immutable string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxy
 
 string base64Encode(const(ubyte)[] data, size_t wrap = 76)
 {
-    auto out = appender!string();
+    auto result = appender!string();
     uint buffer = 0;
     int bits = 0;
     size_t line = 0;
@@ -16,11 +16,11 @@ string base64Encode(const(ubyte)[] data, size_t wrap = 76)
         bits += 8;
         while(bits >= 6) {
             auto idx = (buffer >> (bits - 6)) & 63;
-            out.put(alphabet[idx]);
+            result.put(alphabet[idx]);
             bits -= 6;
             line++;
             if(wrap > 0 && line >= wrap) {
-                out.put('\n');
+                result.put('\n');
                 line = 0;
             }
         }
@@ -28,22 +28,22 @@ string base64Encode(const(ubyte)[] data, size_t wrap = 76)
     if(bits > 0) {
         buffer <<= (6 - bits);
         auto idx = buffer & 63;
-        out.put(alphabet[idx]);
+        result.put(alphabet[idx]);
         line++;
         if(wrap > 0 && line >= wrap) {
-            out.put('\n');
+            result.put('\n');
             line = 0;
         }
     }
     while(line % 4 != 0) {
-        out.put('=');
+        result.put('=');
         line++;
         if(wrap > 0 && line >= wrap) {
-            out.put('\n');
+            result.put('\n');
             line = 0;
         }
     }
-    return out.data;
+    return result.data;
 }
 
 ubyte[] base64Decode(string data, bool ignoreGarbage = false)
@@ -55,7 +55,7 @@ ubyte[] base64Decode(string data, bool ignoreGarbage = false)
         map[cast(ubyte)toLower(ch)] = i;
     }
 
-    auto out = appender!(ubyte[])();
+    auto result = appender!(ubyte[])();
     uint buffer = 0;
     int bits = 0;
     foreach(ch; data) {
@@ -74,10 +74,10 @@ ubyte[] base64Decode(string data, bool ignoreGarbage = false)
         bits += 6;
         if(bits >= 8) {
             auto byte = (buffer >> (bits - 8)) & 0xFF;
-            out.put(cast(ubyte)byte);
+            result.put(cast(ubyte)byte);
             bits -= 8;
         }
     }
-    return out.data;
+    return result.data;
 }
 

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -568,20 +568,20 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             bool blank = line.length == 0;
             if(showTabs) replace(line, "\t", "^I");
             if(showNonPrint) {
-                string out;
+                string outStr;
                 foreach(dchar c; line) {
-                    if(c == '\t' || c == '\n') out ~= cast(char)c;
-                    else if(c < 32) out ~= "^" ~ cast(char)(c + 64);
-                    else if(c == 127) out ~= "^?";
+                    if(c == '\t' || c == '\n') outStr ~= cast(char)c;
+                    else if(c < 32) outStr ~= "^" ~ cast(char)(c + 64);
+                    else if(c == 127) outStr ~= "^?";
                     else if(c > 127) {
                         auto code = c - 128;
-                        out ~= "M-";
-                        if(code < 32) out ~= "^" ~ cast(char)(code + 64);
-                        else if(code == 127) out ~= "^?";
-                        else out ~= cast(char)code;
-                    } else out ~= cast(char)c;
+                        outStr ~= "M-";
+                        if(code < 32) outStr ~= "^" ~ cast(char)(code + 64);
+                        else if(code == 127) outStr ~= "^?";
+                        else outStr ~= cast(char)code;
+                    } else outStr ~= cast(char)c;
                 }
-                line = out;
+                line = outStr;
             }
             if(showEnds) line ~= "$";
             if(squeezeBlank) {
@@ -855,8 +855,6 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         auto dir = std.path.dirName(path);
         if(dir.length == 0) dir = ".";
         writeln(dir);
-    }
-    
     } else if(op == "animal_case") {
         string animal;
         if(tokens.length >= 2) {


### PR DESCRIPTION
## Summary
- fix unmatched brace in `interpreter.d`
- avoid using the reserved word `out` as a variable name
  - update `interpreter.d` processing routine
  - update `base32.d` and `base64.d` implementations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f4cc2e6048327a2e2855c26424066