### PR TITLE
Fix build issues

### DIFF
--- a/src/base32.d
+++ b/src/base32.d
@@ -73,8 +73,8 @@ ubyte[] base32Decode(string data, bool ignoreGarbage = false)
         buffer = (buffer << 5) | cast(uint)idx;
         bits += 5;
         if(bits >= 8) {
-            auto byte = (buffer >> (bits - 8)) & 0xFF;
-            result.put(cast(ubyte)byte);
+            auto b = (buffer >> (bits - 8)) & 0xFF;
+            result.put(cast(ubyte)b);
             bits -= 8;
         }
     }

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -1622,6 +1622,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                     variables[name] = value;
                 }
             }
+        }
     } else if(op == "getopts") {
         getopts.getoptsCommand(tokens);
     } else if(op == "unalias") {


### PR DESCRIPTION
## Summary
- close missing bracket in `interpreter.d`
- avoid using reserved identifier name in `base32.d`

## Testing
- `ldc2 -mtriple=x86_64-pc-linux-gnu src/interpreter.d src/base32.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f4e8c4a0c832780b713482cb0b4e7