### PR TITLE
Fix compile issues with reserved keywords

### DIFF
--- a/src/base64.d
+++ b/src/base64.d
@@ -73,8 +73,8 @@ ubyte[] base64Decode(string data, bool ignoreGarbage = false)
         buffer = (buffer << 6) | cast(uint)idx;
         bits += 6;
         if(bits >= 8) {
-            auto byte = (buffer >> (bits - 8)) & 0xFF;
-            result.put(cast(ubyte)byte);
+            auto bval = (buffer >> (bits - 8)) & 0xFF;
+            result.put(cast(ubyte)bval);
             bits -= 8;
         }
     }

--- a/src/cmp.d
+++ b/src/cmp.d
@@ -79,7 +79,7 @@ bool cmpFiles(string f1, string f2, size_t ignore=0, bool printChars=false, bool
         differ = true;
         if(!quiet && !listDiffs && !printChars) {
             line = 1;
-            foreach(idx, byte; a[0 .. minLen]) if(byte == '\n') line++;
+            foreach(idx, bval; a[0 .. minLen]) if(bval == '\n') line++;
             size_t off = minLen + 1 + ignore;
             if(a.length < b.length)
                 writeln("cmp: EOF on ", f1, " after byte ", off-1, ", line ", line);

--- a/src/comm.d
+++ b/src/comm.d
@@ -31,9 +31,9 @@ bool isSorted(string[] arr)
 
 string repeatDelim(string d, int n)
 {
-    string out;
-    foreach(i; 0 .. n) out ~= d;
-    return out;
+    string result;
+    foreach(i; 0 .. n) result ~= d;
+    return result;
 }
 
 void commFiles(string f1, string f2, bool s1=false, bool s2=false, bool s3=false,


### PR DESCRIPTION
## Summary
- rename variables that conflicted with D keywords
- fix operator precedence in `cpio.d`
- use octal format compatible with D

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f4fe9f558832785ec28ff939e3d3c