### PR TITLE
Fix D compilation errors

### DIFF
--- a/src/cpio.d
+++ b/src/cpio.d
@@ -3,7 +3,7 @@ module cpio;
 import std.stdio;
 import std.file : read, write, dirEntries, SpanMode, mkdir, FileException,
                   isDir, getSize;
-import std.conv : to;
+import std.conv : to, octal;
 import std.path : baseName;
 import std.format : format;
 
@@ -103,7 +103,7 @@ void extractArchive(string archive) {
     auto entries = readArchive(archive);
     foreach(e; entries) {
         if(e.isDir) {
-            mkdir(e.name, 0755);
+            mkdir(e.name, octal!"755");
         } else {
             write(e.name, e.data);
         }

--- a/src/cron.d
+++ b/src/cron.d
@@ -48,7 +48,7 @@ bool[] parseField(string field, int minVal, int maxVal) {
                 end = start;
             }
         }
-        foreach(i; start..end+1 by step) {
+        for(int i = start; i <= end; i += step) {
             if(i >= minVal && i <= maxVal) mask[i] = true;
         }
     }

--- a/src/cut.d
+++ b/src/cut.d
@@ -46,13 +46,13 @@ bool inRanges(size_t idx, Range[] ranges) {
 }
 
 string cutBytes(string line, Range[] ranges) {
-    string out;
+    string result;
     size_t i = 1;
     foreach(ch; line) {
-        if(inRanges(i, ranges)) out ~= ch;
+        if(inRanges(i, ranges)) result ~= ch;
         i++;
     }
-    return out;
+    return result;
 }
 
 string cutFields(string line, Range[] ranges, char delim, bool onlyDelim, string outDelim) {
@@ -153,16 +153,16 @@ void cutCommand(string[] tokens) {
             string line;
             while((line = readln()) !is null) {
                 auto l = line.stripRight("\n");
-                auto out = processLine(l);
-                if(out.length || !onlyDelim)
-                    writeln(out);
+                auto resultLine = processLine(l);
+                if(resultLine.length || !onlyDelim)
+                    writeln(resultLine);
             }
         } else {
             try {
                 foreach(line; readText(f).splitLines) {
-                    auto out = processLine(line);
-                    if(out.length || !onlyDelim)
-                        writeln(out);
+                    auto resultLine = processLine(line);
+                    if(resultLine.length || !onlyDelim)
+                        writeln(resultLine);
                 }
             } catch(Exception) {
                 writeln("cut: cannot read ", f);

--- a/src/date.d
+++ b/src/date.d
@@ -39,28 +39,28 @@ string four(int n) {
 }
 
 string formatDate(SysTime t, string fmt) {
-    string out;
+    string result;
     for(size_t i=0; i<fmt.length; ++i) {
         if(fmt[i] == '%' && i + 1 < fmt.length) {
             auto c = fmt[i+1];
             switch(c) {
-                case '%': out ~= "%"; break;
-                case 'Y': out ~= four(t.year); break;
-                case 'm': out ~= two(t.month); break;
-                case 'd': out ~= two(t.day); break;
-                case 'H': out ~= two(t.hour); break;
-                case 'M': out ~= two(t.minute); break;
-                case 'S': out ~= two(t.second); break;
-                case 'F': out ~= four(t.year) ~ "-" ~ two(t.month) ~ "-" ~ two(t.day); break;
-                case 'T': out ~= two(t.hour) ~ ":" ~ two(t.minute) ~ ":" ~ two(t.second); break;
-                default: out ~= "%" ~ c; break;
+                case '%': result ~= "%"; break;
+                case 'Y': result ~= four(t.year); break;
+                case 'm': result ~= two(t.month); break;
+                case 'd': result ~= two(t.day); break;
+                case 'H': result ~= two(t.hour); break;
+                case 'M': result ~= two(t.minute); break;
+                case 'S': result ~= two(t.second); break;
+                case 'F': result ~= four(t.year) ~ "-" ~ two(t.month) ~ "-" ~ two(t.day); break;
+                case 'T': result ~= two(t.hour) ~ ":" ~ two(t.minute) ~ ":" ~ two(t.second); break;
+                default: result ~= "%" ~ c; break;
             }
             i++;
         } else {
-            out ~= fmt[i];
+            result ~= fmt[i];
         }
     }
-    return out;
+    return result;
 }
 
 void dateCommand(string[] tokens) {

--- a/src/dir.d
+++ b/src/dir.d
@@ -7,16 +7,16 @@ import std.format : format;
 
 string escapeName(string name)
 {
-    string out;
+    string result;
     foreach(dchar c; name) {
         if(c == '\\')
-            out ~= "\\\\";
+            result ~= "\\\\";
         else if(c < 32 || c == 127)
-            out ~= "\\" ~ format("%03o", cast(int)c);
+            result ~= "\\" ~ format("%03o", cast(int)c);
         else
-            out ~= cast(char)c;
+            result ~= cast(char)c;
     }
-    return out;
+    return result;
 }
 
 void dirCommand(string[] tokens)

--- a/src/du.d
+++ b/src/du.d
@@ -31,12 +31,12 @@ string humanSize(ulong bytes, bool si)
 
 void printEntry(ulong bytes, string path, ref Options opts)
 {
-    string out;
+    string result;
     if(opts.human)
-        out = humanSize(bytes, opts.si);
+        result = humanSize(bytes, opts.si);
     else
-        out = to!string(bytes / opts.blockSize);
-    writeln(out, "\t", path);
+        result = to!string(bytes / opts.blockSize);
+    writeln(result, "\t", path);
 }
 
 ulong walk(string path, int depth, ref Options opts)

--- a/src/expand.d
+++ b/src/expand.d
@@ -28,30 +28,30 @@ int spacesFor(size_t col, int[] stops) {
 }
 
 string expandLine(string line, int[] stops, bool initialOnly) {
-    auto out = appender!string();
+    auto builder = appender!string();
     size_t col = 0;
     bool initial = true;
     foreach(ch; line) {
         if(ch == '\b') {
-            out.put(ch);
+              builder.put(ch);
             if(col > 0) col--; 
             continue;
         }
         if(ch == '\t') {
             if(initialOnly && !initial) {
-                out.put(ch);
+                  builder.put(ch);
             } else {
                 int n = spacesFor(col, stops);
-                foreach(i; 0 .. n) out.put(' ');
+                  foreach(i; 0 .. n) builder.put(' ');
                 col += n;
             }
         } else {
-            out.put(ch);
+              builder.put(ch);
             col++;
             if(ch != ' ' && ch != '\t') initial = false;
         }
     }
-    return out.data;
+      return builder.data;
 }
 
 void expandFile(string name, int[] stops, bool initialOnly) {

--- a/src/fmt.d
+++ b/src/fmt.d
@@ -10,20 +10,20 @@ string[] formatParagraph(string para, size_t width)
 {
     auto words = para.split();
     string line;
-    string[] out;
+    string[] result;
     foreach(w; words) {
         if(line.length == 0) {
             line = w;
         } else if(line.length + 1 + w.length <= width) {
             line ~= " " ~ w;
         } else {
-            out ~= line;
+            result ~= line;
             line = w;
         }
     }
     if(line.length)
-        out ~= line;
-    return out;
+          result ~= line;
+    return result;
 }
 
 void processLines(string[] lines, size_t width, bool splitOnly, bool uniform)

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -121,22 +121,22 @@ string formatValue(Value v) {
 }
 
 string unescape(string s) {
-    string out;
+    string result;
     for(size_t i = 0; i < s.length; i++) {
         auto c = s[i];
         if(c == '\\' && i + 1 < s.length) {
             auto n = s[i+1];
             switch(n) {
-                case 'a': out ~= "\a"; break;
-                case 'b': out ~= "\b"; break;
-                case 'c': return out; // suppress trailing newline
-                case 'e': case 'E': out ~= "\x1b"; break;
-                case 'f': out ~= "\f"; break;
-                case 'n': out ~= "\n"; break;
-                case 'r': out ~= "\r"; break;
-                case 't': out ~= "\t"; break;
-                case 'v': out ~= "\v"; break;
-                case '\\': out ~= "\\"; break;
+                case 'a': result ~= "\a"; break;
+                case 'b': result ~= "\b"; break;
+                case 'c': return result; // suppress trailing newline
+                case 'e': case 'E': result ~= "\x1b"; break;
+                case 'f': result ~= "\f"; break;
+                case 'n': result ~= "\n"; break;
+                case 'r': result ~= "\r"; break;
+                case 't': result ~= "\t"; break;
+                case 'v': result ~= "\v"; break;
+                case '\\': result ~= "\\"; break;
                 case 'x': {
                     string hx; size_t j = i + 2;
                     while(j < s.length && hx.length < 2 &&
@@ -145,9 +145,9 @@ string unescape(string s) {
                            (s[j] >= 'A' && s[j] <= 'F'))) {
                         hx ~= s[j]; j++; }
                     if(hx.length) {
-                        out ~= cast(char)to!int("0x" ~ hx);
+                        result ~= cast(char)to!int("0x" ~ hx);
                         i = j - 1;
-                    } else out ~= 'x';
+                    } else result ~= 'x';
                     break; }
                 case '0': case '1': case '2': case '3': case '4':
                 case '5': case '6': case '7': {
@@ -155,7 +155,7 @@ string unescape(string s) {
                     while(j < s.length && j < i + 4 &&
                           s[j] >= '0' && s[j] <= '7') {
                         oc ~= s[j]; j++; }
-                    out ~= cast(char)to!int(oc, 8);
+                    result ~= cast(char)to!int(oc, 8);
                     i = j - 1; break; }
                 case 'u': case 'U': {
                     size_t maxLen = n == 'u' ? 4 : 8;
@@ -167,19 +167,19 @@ string unescape(string s) {
                         hx ~= s[j]; j++; }
                     if(hx.length) {
                         dchar val = cast(dchar)to!int("0x" ~ hx);
-                        out ~= std.utf.toUTF8(val);
+                        result ~= std.utf.toUTF8(val);
                         i = j - 1;
-                    } else out ~= n;
+                    } else result ~= n;
                     break; }
                 default:
-                    out ~= n; break;
+            result ~= n; break;
             }
             i++; // skip the escape code
         } else {
-            out ~= c;
+            result ~= c;
         }
     }
-    return out;
+    return result;
 }
 
 class LfeParser : Parser {
@@ -1049,25 +1049,25 @@ Value evalList(Expr e) {
         auto argsVal = evalExpr(e.list[2]);
         if(argsVal.kind != ValueKind.List)
             throw new Exception("badarg");
-        string out;
+        string result;
         size_t ai = 0;
         for(size_t i = 0; i < fmt.length; i++) {
             if(fmt[i] == '~' && i + 1 < fmt.length) {
                 auto n = fmt[i+1];
                 if(n == 'w') {
                     if(ai >= argsVal.list.length) throw new Exception("badarg");
-                    out ~= formatValue(argsVal.list[ai++]);
+                    result ~= formatValue(argsVal.list[ai++]);
                     i++;
                     continue;
                 } else if(n == 'n') {
-                    out ~= "\n";
+                    result ~= "\n";
                     i++;
                     continue;
                 }
             }
-            out ~= fmt[i];
+            result ~= fmt[i];
         }
-        write(out);
+        write(result);
         return atomVal("ok");
     } else if(head == "echo") {
         bool newline = true;
@@ -1084,15 +1084,15 @@ Value evalList(Expr e) {
                 idx++;
             } else break;
         }
-        string out;
+        string output;
         for(size_t i = idx; i < e.list.length; i++) {
             auto val = evalExpr(e.list[i]);
-            out ~= formatValue(val);
-            if(i + 1 < e.list.length) out ~= " ";
+            output ~= formatValue(val);
+            if(i + 1 < e.list.length) output ~= " ";
         }
-        if(interpret) out = unescape(out);
-        if(newline) out ~= "\n";
-        write(out);
+        if(interpret) output = unescape(output);
+        if(newline) output ~= "\n";
+        write(output);
         return atomVal("ok");
     } else if(head == "cp") {
         auto srcVal = evalExpr(e.list[1]);

--- a/src/ls.d
+++ b/src/ls.d
@@ -20,19 +20,19 @@ string permString(uint mode)
         case S_IFSOCK: type = 's'; break;
         default: break;
     }
-    string out;
-    out ~= type;
+    string result;
+    result ~= type;
     uint[9] bits = [S_IRUSR,S_IWUSR,S_IXUSR,S_IRGRP,S_IWGRP,S_IXGRP,S_IROTH,S_IWOTH,S_IXOTH];
     foreach(i,b; bits) {
         if(mode & b) {
             final switch(i%3) {
-                case 0: out ~= 'r'; break;
-                case 1: out ~= 'w'; break;
-                case 2: out ~= 'x'; break;
+                  case 0: result ~= 'r'; break;
+                  case 1: result ~= 'w'; break;
+                  case 2: result ~= 'x'; break;
             }
-        } else out ~= '-';
+        } else result ~= '-';
     }
-    return out;
+    return result;
 }
 
 void lsCommand(string[] tokens)


### PR DESCRIPTION
## Summary
- update deprecated octal literal usage in `cpio.d`
- replace reserved identifier usage and fix range stepping in modules
- rename local `out` variables across modules to avoid keyword conflict

## Testing
- `ldc2 -mtriple=x86_64-pc-linux-gnu src/*.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f50cba99c8327b474c76aadc24cd2