### PR TITLE
Fix compile issues from reserved words and syntax

### DIFF
--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -5,7 +5,7 @@ import std.file : readText;
 import std.string : splitLines, strip, join;
 import std.algorithm : filter, map;
 
-immutable string defaultDB = q"EOF"
+immutable string defaultDB = q{
 # Default color database
 DIR 01;34
 LINK 01;36
@@ -15,7 +15,7 @@ BLK 40;33;01
 CHR 40;33;01
 ORPHAN 40;31;01
 EXEC 01;32
-EOF";
+};
 
 string loadDB(string name)
 {

--- a/src/expr.d
+++ b/src/expr.d
@@ -210,10 +210,11 @@ private Value parseAnd(string[] tokens, ref size_t idx) {
     while(idx < tokens.length && tokens[idx] == "&") {
         idx++;
         auto rhs = parseCompare(tokens, idx);
-        if(truthy(val) && truthy(rhs))
-            ; // keep val
-        else
+        if(truthy(val) && truthy(rhs)) {
+            /* keep current value */
+        } else {
             val = makeNumber(0);
+        }
     }
     return val;
 }

--- a/src/false.d
+++ b/src/false.d
@@ -1,4 +1,4 @@
-module false;
+module cmd_false;
 
 import core.stdc.stdlib : exit;
 

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -1438,8 +1438,8 @@ Value evalList(Expr e) {
     } else if(head == "attach") {
         auto parent = valueToString(evalExpr(e.list[1]));
         auto child = valueToString(evalExpr(e.list[2]));
-        auto alias = valueToString(evalExpr(e.list[3]));
-        bool ok = objectsystem.attach(parent, child, alias);
+        auto aliasName = valueToString(evalExpr(e.list[3]));
+        bool ok = objectsystem.attach(parent, child, aliasName);
         return atomVal(ok ? "true" : "false");
     } else if(head == "detach") {
         auto parent = valueToString(evalExpr(e.list[1]));

--- a/src/objectsystem.d
+++ b/src/objectsystem.d
@@ -217,9 +217,9 @@ bool emit(string obj, string event, string data) {
     return true;
 }
 
-bool attach(string parent, string child, string alias) {
+bool attach(string parent, string child, string aliasName) {
     if(parent !in registry || child !in registry) return false;
-    registry[parent].children ~= alias;
+    registry[parent].children ~= aliasName;
     registry[child].parent = parent;
     return true;
 }


### PR DESCRIPTION
## Summary
- sanitize heredoc string in `dircolors.d`
- replace empty statement with braces in `expr.d`
- rename `false` module to avoid reserved word
- avoid using reserved keyword `alias` as variable names

## Testing
- `ldc2 -mtriple=x86_64-pc-linux-gnu src/false.d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f521464348327a47ab3bca03c1d5e