### PR TITLE
Fix D compilation errors

### DIFF
--- a/src/cksum.d
+++ b/src/cksum.d
@@ -5,7 +5,7 @@ import std.file : read;
 
 private immutable uint[256] crcTable = generateTable();
 
-private immutable uint[256] generateTable() {
+private immutable(uint[256]) generateTable() {
     uint[256] tab;
     enum uint POLY = 0xEDB88320;
     foreach(i; 0 .. 256) {

--- a/src/cron.d
+++ b/src/cron.d
@@ -3,7 +3,7 @@ module cron;
 import std.stdio;
 import std.file : readText, exists;
 import std.datetime : Clock, SysTime;
-import std.process : system;
+import core.stdc.stdlib : system;
 import std.conv : to;
 import std.algorithm : splitter;
 import core.thread : Thread;

--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -5,7 +5,7 @@ import std.file : readText;
 import std.string : splitLines, strip, join;
 import std.algorithm : filter, map;
 
-immutable string defaultDB = q{
+immutable string defaultDB = q"EOF"
 # Default color database
 DIR 01;34
 LINK 01;36
@@ -15,7 +15,7 @@ BLK 40;33;01
 CHR 40;33;01
 ORPHAN 40;31;01
 EXEC 01;32
-};
+EOF";
 
 string loadDB(string name)
 {

--- a/src/dlexer.d
+++ b/src/dlexer.d
@@ -1,6 +1,6 @@
 module dlexer;
 
-import std.regex : regex, match, Captures;
+import std.regex : regex, match, Captures, Regex;
 import std.array : array;
 import std.string : strip;
 

--- a/src/dmesg.d
+++ b/src/dmesg.d
@@ -2,7 +2,7 @@ module dmesg;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system dmesg command with the provided arguments.
 void dmesgCommand(string[] tokens)

--- a/src/eject.d
+++ b/src/eject.d
@@ -2,7 +2,7 @@ module eject;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system eject command with the provided arguments.
 void ejectCommand(string[] tokens)

--- a/src/fdformat.d
+++ b/src/fdformat.d
@@ -2,7 +2,7 @@ module fdformat;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system fdformat command with the provided arguments.
 void fdformatCommand(string[] tokens)

--- a/src/fsck.d
+++ b/src/fsck.d
@@ -2,7 +2,7 @@ module fsck;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system fsck command with the provided arguments.
 void fsckCommand(string[] tokens)

--- a/src/getfacl.d
+++ b/src/getfacl.d
@@ -2,7 +2,7 @@ module getfacl;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system getfacl command with the provided arguments.
 void getfaclCommand(string[] tokens)

--- a/src/groupadd.d
+++ b/src/groupadd.d
@@ -2,7 +2,7 @@ module groupadd;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system groupadd command with the provided arguments.
 void groupaddCommand(string[] tokens)

--- a/src/groupdel.d
+++ b/src/groupdel.d
@@ -2,7 +2,7 @@ module groupdel;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system groupdel command with the provided arguments.
 void groupdelCommand(string[] tokens)

--- a/src/groupmod.d
+++ b/src/groupmod.d
@@ -2,7 +2,7 @@ module groupmod;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system groupmod command with the provided arguments.
 void groupmodCommand(string[] tokens)

--- a/src/groups.d
+++ b/src/groups.d
@@ -2,7 +2,7 @@ module groups;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system groups command with the provided arguments.
 void groupsCommand(string[] tokens)

--- a/src/gzip.d
+++ b/src/gzip.d
@@ -2,7 +2,7 @@ module gzip;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system gzip command with the provided arguments.
 void gzipCommand(string[] tokens)

--- a/src/iconv.d
+++ b/src/iconv.d
@@ -2,7 +2,7 @@ module iconv;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system iconv command with the provided arguments.
 void iconvCommand(string[] tokens)

--- a/src/id.d
+++ b/src/id.d
@@ -2,7 +2,7 @@ module id;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system id command with the provided arguments.
 void idCommand(string[] tokens)

--- a/src/ifcmd.d
+++ b/src/ifcmd.d
@@ -2,7 +2,7 @@ module ifcmd;
 
 import std.stdio;
 import std.string : join, replace;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Evaluate a shell if statement using /bin/sh.
 void ifCommand(string[] tokens)

--- a/src/ifconfig.d
+++ b/src/ifconfig.d
@@ -2,7 +2,7 @@ module ifconfig;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system ifconfig command with the provided arguments.
 void ifconfigCommand(string[] tokens)

--- a/src/ifdown.d
+++ b/src/ifdown.d
@@ -2,7 +2,7 @@ module ifdown;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system ifdown command with the provided arguments.
 void ifdownCommand(string[] tokens)

--- a/src/ifup.d
+++ b/src/ifup.d
@@ -2,7 +2,7 @@ module ifup;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system ifup command with the provided arguments.
 void ifupCommand(string[] tokens)

--- a/src/importcmd.d
+++ b/src/importcmd.d
@@ -2,7 +2,7 @@ module importcmd;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system import command with the provided arguments.
 void importCommand(string[] tokens)

--- a/src/install.d
+++ b/src/install.d
@@ -2,7 +2,7 @@ module install;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system install command with the provided arguments.
 void installCommand(string[] tokens)

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -6,7 +6,7 @@ import std.parallelism;
 import std.range;
 import std.file : chdir, getcwd, dirEntries, SpanMode, readText,
     copy, rename, remove, mkdir, rmdir, exists;
-import std.process : system, environment;
+import core.stdc.stdlib : system, environment;
 version(Posix) import core.sys.posix.unistd : chroot, execvp;
 import std.regex : regex, matchFirst;
 import std.path : globMatch;

--- a/src/iostat.d
+++ b/src/iostat.d
@@ -2,7 +2,7 @@ module iostat;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system iostat command with the provided arguments.
 void iostatCommand(string[] tokens)

--- a/src/ip.d
+++ b/src/ip.d
@@ -2,7 +2,7 @@ module ip;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system ip command with the provided arguments.
 void ipCommand(string[] tokens)

--- a/src/join.d
+++ b/src/join.d
@@ -2,7 +2,7 @@ module join;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system join command with the provided arguments.
 void joinCommand(string[] tokens)

--- a/src/kill.d
+++ b/src/kill.d
@@ -2,7 +2,7 @@ module kill;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system kill command with the provided arguments.
 void killCommand(string[] tokens)

--- a/src/killall.d
+++ b/src/killall.d
@@ -2,7 +2,7 @@ module killall;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system killall command with the provided arguments.
 void killallCommand(string[] tokens)

--- a/src/klist.d
+++ b/src/klist.d
@@ -2,7 +2,7 @@ module klist;
 
 import std.stdio;
 import std.string : join;
-import std.process : system;
+import core.stdc.stdlib : system;
 
 /// Execute the system klist command with the provided arguments.
 void klistCommand(string[] tokens)

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -15,7 +15,7 @@ import std.parallelism;
 import cpio : createArchive, extractArchive;
 import core.sync.mutex : Mutex;
 import core.sync.condition : Condition;
-import std.process : system;
+import core.stdc.stdlib : system;
 version(Posix) import core.sys.posix.unistd : execvp;
 import objectsystem;
 import local;


### PR DESCRIPTION
## Summary
- adjust regex import for Regex type
- convert token string to regular multi-line string in `dircolors.d`
- return an immutable CRC table correctly in `cksum.d`
- use `core.stdc.stdlib` system function across modules

## Testing
- `ldc2 --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5307c3388327b4e706c09502c6fc