### PR TITLE
Fix heredoc syntax in dircolors.d

### DIFF
--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -15,7 +15,8 @@ BLK 40;33;01
 CHR 40;33;01
 ORPHAN 40;31;01
 EXEC 01;32
-EOF";
+EOF"
+;
 
 string loadDB(string name)
 {


### PR DESCRIPTION
## Summary
- fix the heredoc closing delimiter in `dircolors.d`

## Testing
- `ldc2 -mtriple=x86_64-pc-linux-gnu src/*.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f53d615948327808d1fabed6d588f