### PR TITLE
Fix heredoc error

### DIFF
--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -5,7 +5,7 @@ import std.file : readText;
 import std.string : splitLines, strip, join;
 import std.algorithm : filter, map;
 
-immutable string defaultDB = q"EOF"
+immutable string defaultDB = q{
 # Default color database
 DIR 01;34
 LINK 01;36
@@ -15,8 +15,7 @@ BLK 40;33;01
 CHR 40;33;01
 ORPHAN 40;31;01
 EXEC 01;32
-EOF"
-;
+};
 
 string loadDB(string name)
 {


### PR DESCRIPTION
## Summary
- fix heredoc delimiter in `src/dircolors.d`

## Testing
- `N/A` (build tools missing)

------
https://chatgpt.com/codex/tasks/task_e_685f549369f48327a6cb853c66fd01d7