### PR TITLE
Fix missing imports for D compiler

### DIFF
--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -6,7 +6,7 @@ import std.parallelism;
 import std.range;
 import std.file : chdir, getcwd, dirEntries, SpanMode, readText,
     copy, rename, remove, mkdir, rmdir, exists;
-import core.stdc.stdlib : system, environment;
+import std.process : system, environment;
 version(Posix) import core.sys.posix.unistd : chroot, execvp;
 import std.regex : regex, matchFirst;
 import std.path : globMatch;

--- a/src/linkcmd.d
+++ b/src/linkcmd.d
@@ -1,7 +1,7 @@
 module linkcmd;
 
 import std.stdio;
-import std.file : link;
+import core.sys.posix.unistd : link;
 
 /// Create a hard link.
 void linkCommand(string[] tokens)

--- a/src/ln.d
+++ b/src/ln.d
@@ -1,7 +1,8 @@
 module ln;
 
 import std.stdio;
-import std.file : link, symlink, remove, exists, isDir;
+import std.file : remove, exists, isDir;
+import core.sys.posix.unistd : link, symlink;
 import std.path : baseName, buildPath;
 
 /// Simplified ln implementation supporting -s, -f and -v.

--- a/src/look.d
+++ b/src/look.d
@@ -2,7 +2,8 @@ module look;
 
 import std.stdio;
 import std.string : toLower, strip;
-import std.file : readText, File;
+import std.file : readText;
+import std.stdio : File;
 import std.algorithm : filter;
 import std.ascii : isAlphaNum;
 


### PR DESCRIPTION
## Summary
- correct module imports for interpreter, linkcmd, ln, and look utilities

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685f55969ae483279f14d59f37a9f147