### PR TITLE
Fix imports for system and chroot

### DIFF
--- a/src/crontab.d
+++ b/src/crontab.d
@@ -2,7 +2,8 @@ module crontab;
 
 import std.stdio;
 import std.file : readText, write, exists, remove;
-import std.process : environment, system;
+import std.process : environment;
+import core.stdc.stdlib : system;
 
 void editFile(string path)
 {

--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -5,7 +5,7 @@ import std.file : readText;
 import std.string : splitLines, strip, join;
 import std.algorithm : filter, map;
 
-immutable string defaultDB = q{
+immutable string defaultDB = q"EOF"
 # Default color database
 DIR 01;34
 LINK 01;36
@@ -15,7 +15,7 @@ BLK 40;33;01
 CHR 40;33;01
 ORPHAN 40;31;01
 EXEC 01;32
-};
+EOF";
 
 string loadDB(string name)
 {

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -6,8 +6,10 @@ import std.parallelism;
 import std.range;
 import std.file : chdir, getcwd, dirEntries, SpanMode, readText,
     copy, rename, remove, mkdir, rmdir, exists;
-import std.process : system, environment;
-version(Posix) import core.sys.posix.unistd : chroot, execvp;
+import std.process : environment;
+import core.stdc.stdlib : system;
+version(Posix) import core.sys.posix.unistd : execvp;
+version(Posix) extern(C) int chroot(const char* path);
 import std.regex : regex, matchFirst;
 import std.path : globMatch;
 import std.conv : to;


### PR DESCRIPTION
## Summary
- fix `defaultDB` string literal for dircolors
- import `system` from C standard lib
- declare `chroot` manually to avoid missing import

## Testing
- `ldc2 -mtriple=x86_64-pc-linux-gnu src/*.d -of=interpreter` *(fails: command not found)*
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685f5803c4e083279a4e24c7e95d8e9c