### PR TITLE
Fix D compilation issues

### DIFF
--- a/src/cron.d
+++ b/src/cron.d
@@ -3,7 +3,7 @@ module cron;
 import std.stdio;
 import std.file : readText, exists;
 import std.datetime : Clock, SysTime;
-import std.process : system;
+import core.stdc.stdlib : system;
 import std.conv : to;
 import std.algorithm : splitter;
 import std.string : split, indexOf, strip, startsWith, join, splitLines;

--- a/src/crontab.d
+++ b/src/crontab.d
@@ -2,7 +2,8 @@ module crontab;
 
 import std.stdio;
 import std.file : readText, write, exists, remove;
-import std.process : environment, system;
+import std.process : environment;
+import core.stdc.stdlib : system;
 import std.string : startsWith;
 
 void editFile(string path)

--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -5,7 +5,7 @@ import std.file : readText;
 import std.string : splitLines, strip, join;
 import std.algorithm : filter, map;
 
-immutable string defaultDB = q"DB"
+immutable string defaultDB = `
 # Default color database
 DIR 01;34
 LINK 01;36
@@ -15,7 +15,7 @@ BLK 40;33;01
 CHR 40;33;01
 ORPHAN 40;31;01
 EXEC 01;32
-DB";
+`;
 
 string loadDB(string name)
 {


### PR DESCRIPTION
## Summary
- fix compile errors in cron and crontab by importing `system` from `core.stdc.stdlib`
- replace token-string usage in `dircolors.d` with a raw string literal so any D version can build

## Testing
- `ldc2 --version 2>&1 | head -n 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5ecf3f8c8327b6123225d5b8d3ce