### PR TITLE
Fix compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The implementation is intentionally small and demonstrates how one might begin t
 A D compiler such as `dmd` or `ldc2` is required. To cross compile for a specific target, supply the desired architecture flags to the compiler. For example:
 
 ```bash
-ldc2 -betterC --nodefaultlib -I=std -I=src -mtriple=<target> src/*.d -of=interpreter
+ldc2 -betterC --nodefaultlib -I=. -mtriple=<target> src/*.d -of=interpreter
 ```
 
 Replace `<target>` with the appropriate triple for the operating system described in the `internetcomputer` repository.


### PR DESCRIPTION
## Summary
- correct build instructions to use the repository root as the import path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f6b7b1f588327acfb00d31bbd840d