### PR TITLE
Rename custom std modules to mstd

### DIFF
--- a/mstd/algorithm.d
+++ b/mstd/algorithm.d
@@ -1,4 +1,4 @@
-module std.algorithm;
+module mstd.algorithm;
 
 // Minimal implementations of selected std.algorithm utilities used in this project.
 

--- a/mstd/array.d
+++ b/mstd/array.d
@@ -1,4 +1,4 @@
-module std.array;
+module mstd.array;
 
 // Minimal implementations of selected std.array utilities.
 

--- a/mstd/ascii.d
+++ b/mstd/ascii.d
@@ -1,4 +1,4 @@
-module std.ascii;
+module mstd.ascii;
 
 /// Returns true if the character is alphanumeric.
 bool isAlphaNum(dchar c)

--- a/mstd/conv.d
+++ b/mstd/conv.d
@@ -1,4 +1,4 @@
-module std.conv;
+module mstd.conv;
 
 import core.stdc.stdlib : atoi, strtol, strtoll, strtod;
 import core.stdc.stdio : sprintf;

--- a/mstd/datetime.d
+++ b/mstd/datetime.d
@@ -1,4 +1,4 @@
-module std.datetime;
+module mstd.datetime;
 
 import core.stdc.time;
 

--- a/mstd/digest/md.d
+++ b/mstd/digest/md.d
@@ -1,4 +1,4 @@
-module std.digest.md;
+module mstd.digest.md;
 
 // Minimal MD5 implementation in D based on RFC 1321.
 import core.stdc.string : memcpy;

--- a/mstd/file.d
+++ b/mstd/file.d
@@ -1,4 +1,4 @@
-module std.file;
+module mstd.file;
 
 // Import POSIX filesystem helpers.  Alias `getcwd` to avoid colliding with the
 // wrapper function defined below.

--- a/mstd/format.d
+++ b/mstd/format.d
@@ -1,4 +1,4 @@
-module std.format;
+module mstd.format;
 
 import core.stdc.stdio : vsnprintf;
 import core.stdc.stdarg;

--- a/mstd/path.d
+++ b/mstd/path.d
@@ -1,6 +1,6 @@
-module std.path;
+module mstd.path;
 
-import std.string : split, join;
+import mstd.string : split, join;
 
 string baseName(string path)
 {

--- a/mstd/process.d
+++ b/mstd/process.d
@@ -1,4 +1,4 @@
-module std.process;
+module mstd.process;
 
 string[string] environment;
 
@@ -11,7 +11,7 @@ static this()
         size_t i = 0;
         while(environ[i])
         {
-            import std.string : split, toStringz;
+            import mstd.string : split, toStringz;
             auto pair = split(environ[i].fromStringz, "=");
             if(pair.length >= 2)
                 environment[pair[0]] = pair[1];

--- a/mstd/range.d
+++ b/mstd/range.d
@@ -1,4 +1,4 @@
-module std.range;
+module mstd.range;
 
 struct Iota
 {

--- a/mstd/regex.d
+++ b/mstd/regex.d
@@ -1,6 +1,6 @@
-module std.regex;
+module mstd.regex;
 
-import std.string : toLower, indexOf;
+import mstd.string : toLower, indexOf;
 
 /// Simple lightweight regex replacement used for ``betterC`` builds.
 ///

--- a/mstd/stdio.d
+++ b/mstd/stdio.d
@@ -1,4 +1,4 @@
-module std.stdio;
+module mstd.stdio;
 
 import core.stdc.stdio;
 

--- a/mstd/string.d
+++ b/mstd/string.d
@@ -1,4 +1,4 @@
-module std.string;
+module mstd.string;
 
 import core.stdc.string : strlen, memcpy, memcmp, strcmp, strcasecmp;
 

--- a/mstd/utf.d
+++ b/mstd/utf.d
@@ -1,4 +1,4 @@
-module std.utf;
+module mstd.utf;
 
 string toUTF8(string s)
 {

--- a/src/awk.d
+++ b/src/awk.d
@@ -1,11 +1,11 @@
 module awk;
 
-import std.stdio;
-import std.file : readText;
-import std.regex : regex, matchFirst;
-import std.string : split, splitLines, stripRight;
-import std.algorithm.searching : canFind;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.regex : regex, matchFirst;
+import mstd.string : split, splitLines, stripRight;
+import mstd.algorithm : canFind;
+import mstd.conv : to;
 
 /// Minimal awk implementation supporting simple print statements.
 void awkCommand(string[] tokens)

--- a/src/base32.d
+++ b/src/base32.d
@@ -1,7 +1,7 @@
 module base32;
 
-import std.array : appender, Appender;
-import std.string : toLower;
+import mstd.array : appender, Appender;
+import mstd.string : toLower;
 
 immutable string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
 

--- a/src/base64.d
+++ b/src/base64.d
@@ -1,7 +1,7 @@
 module base64;
 
-import std.array : appender, Appender;
-import std.string : toLower;
+import mstd.array : appender, Appender;
+import mstd.string : toLower;
 
 immutable string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/src/bc.d
+++ b/src/bc.d
@@ -1,11 +1,11 @@
 module bc;
 
 import dlexer;
-import std.regex : regex;
-import std.array : array;
-import std.algorithm : filter;
+import mstd.regex : regex;
+import mstd.array : array;
+import mstd.algorithm : filter;
 import std.bigint : BigInt;
-import std.conv : to;
+import mstd.conv : to;
 
 class BCParser {
     Token[] tokens;

--- a/src/cal.d
+++ b/src/cal.d
@@ -1,6 +1,6 @@
 module cal;
 
-import std.stdio;
+import mstd.stdio;
 
 bool isLeapYear(int year) {
     return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);

--- a/src/chkconfig.d
+++ b/src/chkconfig.d
@@ -1,10 +1,10 @@
 module chkconfig;
 
-import std.stdio;
-import std.string;
-import std.file : exists, readText, dirEntries, SpanMode, symlink, remove;
-import std.path : baseName;
-import std.conv : to;
+import mstd.stdio;
+import mstd.string;
+import mstd.file : exists, readText, dirEntries, SpanMode, symlink, remove;
+import mstd.path : baseName;
+import mstd.conv : to;
 
 bool serviceEnabled(string name, int level) {
     string dir = "/etc/rc" ~ to!string(level) ~ ".d";

--- a/src/cksum.d
+++ b/src/cksum.d
@@ -1,7 +1,7 @@
 module cksum;
 
-import std.stdio;
-import std.file : read;
+import mstd.stdio;
+import mstd.file : read;
 
 private immutable uint[256] crcTable = generateTable();
 

--- a/src/cmp.d
+++ b/src/cmp.d
@@ -1,9 +1,9 @@
 module cmp;
 
-import std.stdio;
-import std.file : read;
-import std.conv : to;
-import std.array : array;
+import mstd.stdio;
+import mstd.file : read;
+import mstd.conv : to;
+import mstd.array : array;
 
 private string formatChar(ubyte b)
 {

--- a/src/comm.d
+++ b/src/comm.d
@@ -1,8 +1,8 @@
 module comm;
 
-import std.stdio;
-import std.file : readText;
-import std.string : splitLines;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : splitLines;
 
 string[] readLines(string name)
 {

--- a/src/cron.d
+++ b/src/cron.d
@@ -1,12 +1,12 @@
 module cron;
 
-import std.stdio;
-import std.file : readText, exists;
-import std.datetime : Clock, SysTime;
+import mstd.stdio;
+import mstd.file : readText, exists;
+import mstd.datetime : Clock, SysTime;
 import core.stdc.stdlib : system;
-import std.conv : to;
-import std.algorithm : splitter;
-import std.string : split, indexOf, strip, startsWith, join, splitLines;
+import mstd.conv : to;
+import mstd.algorithm : splitter;
+import mstd.string : split, indexOf, strip, startsWith, join, splitLines;
 import core.thread : Thread;
 import core.time : dur;
 

--- a/src/crontab.d
+++ b/src/crontab.d
@@ -1,10 +1,10 @@
 module crontab;
 
-import std.stdio;
-import std.file : readText, write, exists, remove;
-import std.process : environment;
+import mstd.stdio;
+import mstd.file : readText, write, exists, remove;
+import mstd.process : environment;
 import core.stdc.stdlib : system;
-import std.string : startsWith;
+import mstd.string : startsWith;
 
 void editFile(string path)
 {

--- a/src/csplit.d
+++ b/src/csplit.d
@@ -1,11 +1,11 @@
 module csplit;
 
-import std.stdio;
-import std.file : readText, write;
-import std.string : splitLines, join, indexOf;
-import std.regex : regex, matchFirst;
-import std.conv : to;
-import std.format : format;
+import mstd.stdio;
+import mstd.file : readText, write;
+import mstd.string : splitLines, join, indexOf;
+import mstd.regex : regex, matchFirst;
+import mstd.conv : to;
+import mstd.format : format;
 
 struct Pattern {
     bool isRegex;

--- a/src/cut.d
+++ b/src/cut.d
@@ -1,9 +1,9 @@
 module cut;
 
-import std.stdio;
-import std.string : split, splitLines, join, indexOf, startsWith, stripRight;
-import std.file : readText;
-import std.conv : to;
+import mstd.stdio;
+import mstd.string : split, splitLines, join, indexOf, startsWith, stripRight;
+import mstd.file : readText;
+import mstd.conv : to;
 
 struct Range {
     size_t start;

--- a/src/date.d
+++ b/src/date.d
@@ -1,9 +1,9 @@
 module date;
 
-import std.stdio;
-import std.datetime : Clock, SysTime, DateTime;
-import std.conv : to;
-import std.string : split;
+import mstd.stdio;
+import mstd.datetime : Clock, SysTime, DateTime;
+import mstd.conv : to;
+import mstd.string : split;
 
 SysTime parseDateString(string s) {
     try {

--- a/src/dc.d
+++ b/src/dc.d
@@ -1,8 +1,8 @@
 module dc;
 
 import std.bigint : BigInt;
-import std.conv : to;
-import std.string : split, strip;
+import mstd.conv : to;
+import mstd.string : split, strip;
 
 string dcEval(string expr) {
     BigInt[] stack;

--- a/src/dd.d
+++ b/src/dd.d
@@ -1,9 +1,9 @@
 module dd;
 
-import std.stdio;
-import std.file : exists;
-import std.conv : to;
-import std.string : split, indexOf, endsWith;
+import mstd.stdio;
+import mstd.file : exists;
+import mstd.conv : to;
+import mstd.string : split, indexOf, endsWith;
 
 size_t parseBytes(string s)
 {

--- a/src/ddrescue.d
+++ b/src/ddrescue.d
@@ -1,9 +1,9 @@
 module ddrescue;
 
-import std.stdio;
-import std.file : exists, readText, append, write;
-import std.conv : to;
-import std.string : split;
+import mstd.stdio;
+import mstd.file : exists, readText, append, write;
+import mstd.conv : to;
+import mstd.string : split;
 
 size_t parseSize(string s)
 {

--- a/src/df.d
+++ b/src/df.d
@@ -1,11 +1,11 @@
 module df;
 
-import std.stdio;
-import std.file : readText;
-import std.string : split, toStringz;
-import std.algorithm : canFind;
-import std.format : format;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : split, toStringz;
+import mstd.algorithm : canFind;
+import mstd.format : format;
+import mstd.conv : to;
 import core.sys.posix.sys.statvfs;
 
 struct Mount {

--- a/src/diff.d
+++ b/src/diff.d
@@ -1,10 +1,10 @@
 module diff;
 
-import std.stdio;
-import std.file : readText;
-import std.string : splitLines, toLower, strip, join, split;
-import std.algorithm : max;
-import std.array : array;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : splitLines, toLower, strip, join, split;
+import mstd.algorithm : max;
+import mstd.array : array;
 
 struct DiffOp {
     char tag; // ' ' for same, '-' removed from first, '+' added in second

--- a/src/diff3.d
+++ b/src/diff3.d
@@ -1,8 +1,8 @@
 module diff3;
 
-import std.stdio;
-import std.file : readText;
-import std.string : splitLines;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : splitLines;
 
 string[] readLines(string name)
 {

--- a/src/dir.d
+++ b/src/dir.d
@@ -1,9 +1,9 @@
 module dir;
 
-import std.stdio;
-import std.file : dirEntries, SpanMode;
-import std.algorithm : sort;
-import std.format : format;
+import mstd.stdio;
+import mstd.file : dirEntries, SpanMode;
+import mstd.algorithm : sort;
+import mstd.format : format;
 
 string escapeName(string name)
 {

--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -1,9 +1,9 @@
 module dircolors;
 
-import std.stdio;
-import std.file : readText;
-import std.string : splitLines, strip, join;
-import std.algorithm : filter, map;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : splitLines, strip, join;
+import mstd.algorithm : filter, map;
 
 immutable string defaultDB = `
 # Default color database

--- a/src/dirname.d
+++ b/src/dirname.d
@@ -1,7 +1,7 @@
 module dirname;
 
-import std.stdio;
-import std.path : dirName;
+import mstd.stdio;
+import mstd.path : dirName;
 
 void dirnameCommand(string[] tokens)
 {

--- a/src/dlexer.d
+++ b/src/dlexer.d
@@ -1,8 +1,8 @@
 module dlexer;
 
-import std.regex : regex, match, Captures, Regex;
-import std.array : array;
-import std.string : strip;
+import mstd.regex : regex, match, Captures, Regex;
+import mstd.array : array;
+import mstd.string : strip;
 
 /// Represents a lexical token with type and value.
 struct Token {

--- a/src/dmesg.d
+++ b/src/dmesg.d
@@ -1,7 +1,7 @@
 module dmesg;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system dmesg command with the provided arguments.

--- a/src/dos2unix.d
+++ b/src/dos2unix.d
@@ -1,8 +1,8 @@
 module dos2unix;
 
-import std.stdio;
-import std.file : readText, write;
-import std.string : replace;
+import mstd.stdio;
+import mstd.file : readText, write;
+import mstd.string : replace;
 
 void convertFile(string inFile, string outFile, bool keepDate, bool quiet)
 {

--- a/src/dparser.d
+++ b/src/dparser.d
@@ -1,8 +1,8 @@
 module dparser;
 
-import std.stdio;
-import std.array : array;
-import std.algorithm;
+import mstd.stdio;
+import mstd.array : array;
+import mstd.algorithm;
 import dlexer;
 
 alias Action = long delegate(long, long);

--- a/src/du.d
+++ b/src/du.d
@@ -1,10 +1,10 @@
 module du;
 
-import std.stdio;
-import std.file : dirEntries, DirEntry, SpanMode;
-import std.conv : to;
-import std.path : buildNormalizedPath;
-import std.format : format;
+import mstd.stdio;
+import mstd.file : dirEntries, DirEntry, SpanMode;
+import mstd.conv : to;
+import mstd.path : buildNormalizedPath;
+import mstd.format : format;
 
 struct Options {
     bool human;

--- a/src/egrep.d
+++ b/src/egrep.d
@@ -1,10 +1,10 @@
 module egrep;
 
-import std.stdio;
-import std.file : readText;
-import std.regex : regex, matchFirst;
-import std.string : toLower;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.regex : regex, matchFirst;
+import mstd.string : toLower;
+import mstd.conv : to;
 
 void egrepCommand(string[] tokens)
 {

--- a/src/eject.d
+++ b/src/eject.d
@@ -1,7 +1,7 @@
 module eject;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system eject command with the provided arguments.

--- a/src/example.d
+++ b/src/example.d
@@ -2,8 +2,8 @@ module example;
 
 import dlexer;
 import dparser;
-import std.regex : regex;
-import std.stdio;
+import mstd.regex : regex;
+import mstd.stdio;
 
 /// Run the arithmetic parser example.
 void exampleMain(string[] args) {

--- a/src/expand.d
+++ b/src/expand.d
@@ -1,11 +1,11 @@
 module expand;
 
-import std.stdio;
-import std.file : readText;
-import std.string : split, replace, splitLines;
-import std.conv : to;
-import std.array : appender, Appender;
-import std.ascii : isDigit;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : split, replace, splitLines;
+import mstd.conv : to;
+import mstd.array : appender, Appender;
+import mstd.ascii : isDigit;
 
 int[] parseStops(string spec) {
     spec = replace(spec, ",", " ");

--- a/src/expr.d
+++ b/src/expr.d
@@ -1,9 +1,9 @@
 module expr;
 
-import std.stdio;
-import std.conv : to, ConvException;
-import std.regex : regex, matchFirst;
-import std.string : indexOf;
+import mstd.stdio;
+import mstd.conv : to, ConvException;
+import mstd.regex : regex, matchFirst;
+import mstd.string : indexOf;
 
 struct Value {
     bool isNumber;

--- a/src/fdformat.d
+++ b/src/fdformat.d
@@ -1,7 +1,7 @@
 module fdformat;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system fdformat command with the provided arguments.

--- a/src/fdisk.d
+++ b/src/fdisk.d
@@ -1,9 +1,9 @@
 module fdisk;
 
-import std.stdio;
-import std.file : readText, exists, dirEntries, SpanMode;
-import std.string : split, strip;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : readText, exists, dirEntries, SpanMode;
+import mstd.string : split, strip;
+import mstd.conv : to;
 
 void printUsage()
 {

--- a/src/fgrep.d
+++ b/src/fgrep.d
@@ -1,10 +1,10 @@
 module fgrep;
 
-import std.stdio;
-import std.file : readText;
-import std.algorithm.searching : canFind;
-import std.string : toLower;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.algorithm : canFind;
+import mstd.string : toLower;
+import mstd.conv : to;
 
 void fgrepCommand(string[] tokens)
 {

--- a/src/file.d
+++ b/src/file.d
@@ -1,7 +1,7 @@
 module file;
 
-import std.stdio;
-import std.file : read, exists, isDir;
+import mstd.stdio;
+import mstd.file : read, exists, isDir;
 
 bool isText(ubyte[] buf) {
     foreach(b; buf) {

--- a/src/find.d
+++ b/src/find.d
@@ -1,11 +1,11 @@
 module find;
 
-import std.stdio;
-import std.file : dirEntries, SpanMode, isFile, isDir;
-import std.path : baseName, buildPath;
-import std.algorithm : canFind;
-import std.path : globMatch;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : dirEntries, SpanMode, isFile, isDir;
+import mstd.path : baseName, buildPath;
+import mstd.algorithm : canFind;
+import mstd.path : globMatch;
+import mstd.conv : to;
 
 void search(string path, string pattern, bool usePattern, char ftype, int depth, int maxDepth)
 {

--- a/src/fmt.d
+++ b/src/fmt.d
@@ -1,10 +1,10 @@
 module fmt;
 
-import std.stdio;
-import std.string : split, splitLines, strip, join;
-import std.file : readText;
-import std.conv : to;
-import std.ascii : isDigit;
+import mstd.stdio;
+import mstd.string : split, splitLines, strip, join;
+import mstd.file : readText;
+import mstd.conv : to;
+import mstd.ascii : isDigit;
 
 string[] formatParagraph(string para, size_t width)
 {

--- a/src/fold.d
+++ b/src/fold.d
@@ -1,9 +1,9 @@
 module fold;
 
-import std.stdio;
-import std.file : readText;
-import std.string : splitLines, lastIndexOf, stripRight;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.string : splitLines, lastIndexOf, stripRight;
+import mstd.conv : to;
 
 void foldLine(string line, size_t width, bool breakSpaces)
 {

--- a/src/fsck.d
+++ b/src/fsck.d
@@ -1,7 +1,7 @@
 module fsck;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system fsck command with the provided arguments.

--- a/src/fuser.d
+++ b/src/fuser.d
@@ -1,10 +1,10 @@
 module fuser;
 
-import std.stdio;
-import std.file : dirEntries, readLink, exists;
-import std.path : baseName, buildPath;
+import mstd.stdio;
+import mstd.file : dirEntries, readLink, exists;
+import mstd.path : baseName, buildPath;
 import core.sys.posix.signal : kill, SIGKILL;
-import std.conv : to;
+import mstd.conv : to;
 import core.sys.posix.unistd : getpid;
 
 /// List processes using a given file. Supports -k to kill them.

--- a/src/getfacl.d
+++ b/src/getfacl.d
@@ -1,7 +1,7 @@
 module getfacl;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system getfacl command with the provided arguments.

--- a/src/getopts.d
+++ b/src/getopts.d
@@ -1,8 +1,8 @@
 module getopts;
 
-import std.stdio;
-import std.string : strip;
-import std.conv : to;
+import mstd.stdio;
+import mstd.string : strip;
+import mstd.conv : to;
 
 extern __gshared string[string] variables; // from interpreter
 

--- a/src/groupadd.d
+++ b/src/groupadd.d
@@ -1,7 +1,7 @@
 module groupadd;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system groupadd command with the provided arguments.

--- a/src/groupdel.d
+++ b/src/groupdel.d
@@ -1,7 +1,7 @@
 module groupdel;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system groupdel command with the provided arguments.

--- a/src/groupmod.d
+++ b/src/groupmod.d
@@ -1,7 +1,7 @@
 module groupmod;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system groupmod command with the provided arguments.

--- a/src/groups.d
+++ b/src/groups.d
@@ -1,7 +1,7 @@
 module groups;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system groups command with the provided arguments.

--- a/src/gzip.d
+++ b/src/gzip.d
@@ -1,7 +1,7 @@
 module gzip;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system gzip command with the provided arguments.

--- a/src/iconv.d
+++ b/src/iconv.d
@@ -1,7 +1,7 @@
 module iconv;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system iconv command with the provided arguments.

--- a/src/id.d
+++ b/src/id.d
@@ -1,7 +1,7 @@
 module id;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system id command with the provided arguments.

--- a/src/ifcmd.d
+++ b/src/ifcmd.d
@@ -1,7 +1,7 @@
 module ifcmd;
 
-import std.stdio;
-import std.string : join, replace;
+import mstd.stdio;
+import mstd.string : join, replace;
 import core.stdc.stdlib : system;
 
 /// Evaluate a shell if statement using /bin/sh.

--- a/src/ifconfig.d
+++ b/src/ifconfig.d
@@ -1,7 +1,7 @@
 module ifconfig;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system ifconfig command with the provided arguments.

--- a/src/ifdown.d
+++ b/src/ifdown.d
@@ -1,7 +1,7 @@
 module ifdown;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system ifdown command with the provided arguments.

--- a/src/ifup.d
+++ b/src/ifup.d
@@ -1,7 +1,7 @@
 module ifup;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system ifup command with the provided arguments.

--- a/src/importcmd.d
+++ b/src/importcmd.d
@@ -1,7 +1,7 @@
 module importcmd;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system import command with the provided arguments.

--- a/src/install.d
+++ b/src/install.d
@@ -1,7 +1,7 @@
 module install;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system install command with the provided arguments.

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -1,20 +1,20 @@
-import std.stdio;
-import std.string;
-import std.array;
-import std.algorithm;
+import mstd.stdio;
+import mstd.string;
+import mstd.array;
+import mstd.algorithm;
 import std.parallelism;
-import std.range;
-import std.file : chdir, getcwd, dirEntries, SpanMode, readText,
+import mstd.range;
+import mstd.file : chdir, getcwd, dirEntries, SpanMode, readText,
     copy, rename, remove, mkdir, rmdir, exists;
-import std.process : environment;
+import mstd.process : environment;
 import core.stdc.stdlib : system;
 version(Posix) import core.sys.posix.unistd : execvp;
 version(Posix) extern(C) int chroot(const char* path);
-import std.regex : regex, matchFirst;
-import std.path : globMatch;
-import std.conv : to;
+import mstd.regex : regex, matchFirst;
+import mstd.path : globMatch;
+import mstd.conv : to;
 import core.thread : Thread;
-import std.datetime : Clock, SysTime;
+import mstd.datetime : Clock, SysTime;
 import core.time : dur;
 import base32;
 import base64;
@@ -189,7 +189,7 @@ void runParallel(string input) {
 }
 
 string findInPath(string name) {
-    import std.file : exists;
+    import mstd.file : exists;
     auto searchPath = environment.get("PATH", "");
     foreach(p; searchPath.split(":")) {
         string candidate = p.length ? p ~ "/" ~ name : name;
@@ -282,7 +282,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         if(useDefaultPath)
             environment["PATH"] = "/bin:/usr/bin:/usr/local/bin";
 
-        import std.file : exists;
+        import mstd.file : exists;
 
         auto searchPath = environment.get("PATH", "");
         string cmdPath;
@@ -794,7 +794,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             return;
         }
         version(Posix) {
-            import std.string : toStringz;
+            import mstd.string : toStringz;
             import core.stdc.stdlib : exit;
             const(char)*[] args;
             foreach(t; tokens[1 .. $]) args ~= t.toStringz;
@@ -854,7 +854,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             return;
         }
         auto path = tokens[1];
-        auto dir = std.path.dirName(path);
+        auto dir = mstd.path.dirName(path);
         if(dir.length == 0) dir = ".";
         writeln(dir);
     } else if(op == "animal_case") {
@@ -1020,7 +1020,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         }
         foreach(dir; tokens[1 .. $]) {
             try {
-                std.file.mkdir(dir);
+                mstd.file.mkdir(dir);
             } catch(Exception e) {
                 writeln("mkdir: cannot create directory ", dir);
             }
@@ -1032,7 +1032,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         }
         foreach(dir; tokens[1 .. $]) {
             try {
-                std.file.rmdir(dir);
+                mstd.file.rmdir(dir);
             } catch(Exception e) {
                 writeln("rmdir: failed to remove ", dir);
             }
@@ -1056,7 +1056,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             return;
         }
         try {
-            std.file.copy(tokens[1], tokens[2]);
+            mstd.file.copy(tokens[1], tokens[2]);
         } catch(Exception e) {
             writeln("cp: failed to copy");
         }
@@ -1066,7 +1066,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             return;
         }
         try {
-            std.file.rename(tokens[1], tokens[2]);
+            mstd.file.rename(tokens[1], tokens[2]);
         } catch(Exception e) {
             writeln("mv: failed to move");
         }
@@ -1077,7 +1077,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         }
         foreach(f; tokens[1 .. $]) {
             try {
-                std.file.remove(f);
+                mstd.file.remove(f);
             } catch(Exception e) {
                 writeln("rm: cannot remove ", f);
             }
@@ -1200,7 +1200,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         if(device.startsWith("/dev/"))
             device = device[5 .. $];
         string sys = "/sys/block/" ~ device;
-        import std.file : exists, dirEntries;
+        import mstd.file : exists, dirEntries;
         if(!exists(sys)) {
             writeln("cfdisk: device /dev/" ~ device ~ " not found");
             return;
@@ -1656,7 +1656,7 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
         } else if(tokens.length == 3 && tokens[1] == "-r") {
             keyBindings.remove(tokens[2]);
         } else if(tokens.length == 3 && tokens[1] == "-f") {
-            import std.file : readText;
+            import mstd.file : readText;
             try {
                 foreach(line; readText(tokens[2]).splitLines) {
                     auto trimmed = line.strip;

--- a/src/iostat.d
+++ b/src/iostat.d
@@ -1,7 +1,7 @@
 module iostat;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system iostat command with the provided arguments.

--- a/src/ip.d
+++ b/src/ip.d
@@ -1,7 +1,7 @@
 module ip;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system ip command with the provided arguments.

--- a/src/join.d
+++ b/src/join.d
@@ -1,7 +1,7 @@
 module join;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system join command with the provided arguments.

--- a/src/kill.d
+++ b/src/kill.d
@@ -1,7 +1,7 @@
 module kill;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system kill command with the provided arguments.

--- a/src/killall.d
+++ b/src/killall.d
@@ -1,7 +1,7 @@
 module killall;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system killall command with the provided arguments.

--- a/src/klist.d
+++ b/src/klist.d
@@ -1,7 +1,7 @@
 module klist;
 
-import std.stdio;
-import std.string : join;
+import mstd.stdio;
+import mstd.string : join;
 import core.stdc.stdlib : system;
 
 /// Execute the system klist command with the provided arguments.

--- a/src/less.d
+++ b/src/less.d
@@ -1,8 +1,8 @@
 module less;
 
-import std.stdio;
-import std.file : readText;
-import std.algorithm : min;
+import mstd.stdio;
+import mstd.file : readText;
+import mstd.algorithm : min;
 
 /// Very small pager implementation.
 void lessCommand(string[] tokens)

--- a/src/letcmd.d
+++ b/src/letcmd.d
@@ -1,8 +1,8 @@
 module letcmd;
 
-import std.stdio;
-import std.string : split, replace;
-import std.conv : to;
+import mstd.stdio;
+import mstd.string : split, replace;
+import mstd.conv : to;
 import bc : bcEval;
 
 extern __gshared string[string] variables;

--- a/src/lfe.d
+++ b/src/lfe.d
@@ -2,9 +2,9 @@ module lfe;
 
 import dlexer;
 import dparser;
-import std.regex : regex;
-import std.stdio;
-import std.string;
+import mstd.regex : regex;
+import mstd.stdio;
+import mstd.string;
 
 struct Expr {
     bool isList;

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -2,15 +2,15 @@ module lferepl;
 
 import dlexer;
 import dparser;
-import std.regex : regex;
-import std.stdio;
-import std.string;
-import std.ascii : isDigit;
-import std.algorithm;
-import std.array;
-import std.conv : to;
-import std.utf;
-import std.file : readText, copy;
+import mstd.regex : regex;
+import mstd.stdio;
+import mstd.string;
+import mstd.ascii : isDigit;
+import mstd.algorithm;
+import mstd.array;
+import mstd.conv : to;
+import mstd.utf;
+import mstd.file : readText, copy;
 import std.parallelism;
 import cpio : createArchive, extractArchive;
 import core.sync.mutex : Mutex;
@@ -167,7 +167,7 @@ string unescape(string s) {
                         hx ~= s[j]; j++; }
                     if(hx.length) {
                         dchar val = cast(dchar)to!int("0x" ~ hx);
-                        result ~= std.utf.toUTF8(val);
+                        result ~= mstd.utf.toUTF8(val);
                         i = j - 1;
                     } else result ~= n;
                     break; }
@@ -1333,7 +1333,7 @@ Value evalList(Expr e) {
         if(cmd.length >= 2 && cmd[0] == '"' && cmd[$-1] == '"')
             cmd = cmd[1 .. $-1];
         version(Posix) {
-            import std.string : toStringz;
+            import mstd.string : toStringz;
             import core.stdc.stdlib : exit;
             const(char)*[] argv;
             argv ~= cmd.toStringz;

--- a/src/linkcmd.d
+++ b/src/linkcmd.d
@@ -1,6 +1,6 @@
 module linkcmd;
 
-import std.stdio;
+import mstd.stdio;
 import core.sys.posix.unistd : link;
 
 /// Create a hard link.

--- a/src/ln.d
+++ b/src/ln.d
@@ -1,9 +1,9 @@
 module ln;
 
-import std.stdio;
-import std.file : remove, exists, isDir;
+import mstd.stdio;
+import mstd.file : remove, exists, isDir;
 import core.sys.posix.unistd : link, symlink;
-import std.path : baseName, buildPath;
+import mstd.path : baseName, buildPath;
 
 /// Simplified ln implementation supporting -s, -f and -v.
 void lnCommand(string[] tokens)

--- a/src/local.d
+++ b/src/local.d
@@ -1,6 +1,6 @@
 module local;
 
-import std.stdio;
+import mstd.stdio;
 
 /// Minimal local implementation - assigns variables in the global map.
 extern (C) {

--- a/src/locate.d
+++ b/src/locate.d
@@ -1,8 +1,8 @@
 module locate;
 
-import std.stdio;
-import std.file : dirEntries, SpanMode;
-import std.string : indexOf;
+import mstd.stdio;
+import mstd.file : dirEntries, SpanMode;
+import mstd.string : indexOf;
 
 void search(string path, string pattern)
 {

--- a/src/login.d
+++ b/src/login.d
@@ -1,7 +1,7 @@
 module login;
 
-import std.stdio;
-import std.process : environment;
+import mstd.stdio;
+import mstd.process : environment;
 
 /// Very simple login command that sets the LOGNAME and USER environment.
 void loginCommand(string[] tokens)

--- a/src/logname.d
+++ b/src/logname.d
@@ -1,7 +1,7 @@
 module logname;
 
-import std.stdio;
-import std.process : environment;
+import mstd.stdio;
+import mstd.process : environment;
 
 /// Print the current login name.
 void lognameCommand(string[] tokens)

--- a/src/logout.d
+++ b/src/logout.d
@@ -1,7 +1,7 @@
 module logout;
 
-import std.stdio;
-import std.conv : to;
+import mstd.stdio;
+import mstd.conv : to;
 import core.stdc.stdlib : exit;
 
 /// Terminate the shell session.

--- a/src/look.d
+++ b/src/look.d
@@ -1,11 +1,11 @@
 module look;
 
-import std.stdio;
-import std.string : toLower, strip;
-import std.file : readText;
-import std.stdio : File;
-import std.algorithm : filter;
-import std.ascii : isAlphaNum;
+import mstd.stdio;
+import mstd.string : toLower, strip;
+import mstd.file : readText;
+import mstd.stdio : File;
+import mstd.algorithm : filter;
+import mstd.ascii : isAlphaNum;
 
 void lookCommand(string[] tokens)
 {

--- a/src/ls.d
+++ b/src/ls.d
@@ -1,10 +1,10 @@
 module ls;
 
-import std.stdio;
-import std.file : dirEntries, DirEntry, SpanMode;
-import std.algorithm : sort;
-import std.string : format;
-import std.datetime : unixTimeToStdTime, SysTime;
+import mstd.stdio;
+import mstd.file : dirEntries, DirEntry, SpanMode;
+import mstd.algorithm : sort;
+import mstd.string : format;
+import mstd.datetime : unixTimeToStdTime, SysTime;
 import core.sys.posix.sys.stat : S_IFMT, S_IFDIR, S_IFLNK, S_IFCHR, S_IFBLK, S_IFIFO, S_IFSOCK,
     S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IWGRP, S_IXGRP, S_IROTH, S_IWOTH, S_IXOTH;
 

--- a/src/lsblk.d
+++ b/src/lsblk.d
@@ -1,10 +1,10 @@
 module lsblk;
 
-import std.stdio;
-import std.file : dirEntries, readText, exists, SpanMode;
-import std.string : strip;
-import std.algorithm : sort;
-import std.conv : to;
+import mstd.stdio;
+import mstd.file : dirEntries, readText, exists, SpanMode;
+import mstd.string : strip;
+import mstd.algorithm : sort;
+import mstd.conv : to;
 import df : humanSize;
 
 void lsblkCommand(string[] tokens)

--- a/src/lsof.d
+++ b/src/lsof.d
@@ -1,9 +1,9 @@
 module lsof;
 
-import std.stdio;
-import std.file : dirEntries, readLink, readText, SpanMode;
-import std.string : strip;
-import std.algorithm : sort;
+import mstd.stdio;
+import mstd.file : dirEntries, readLink, readText, SpanMode;
+import mstd.string : strip;
+import mstd.algorithm : sort;
 
 bool isNumeric(string s) {
     foreach(ch; s) if(ch < '0' || ch > '9') return false; 

--- a/src/md5sum.d
+++ b/src/md5sum.d
@@ -1,15 +1,15 @@
 module md5sum;
 
-import std.stdio;
-import std.file : read;
-import std.digest.md;
+import mstd.stdio;
+import mstd.file : read;
+import mstd.digest.md;
 
 string hexDigest(const(ubyte)[] data)
 {
     auto ctx = MD5();
     ctx.put(data);
     auto dg = ctx.finish();
-    import std.array : appender;
+    import mstd.array : appender;
     auto app = appender!string();
     foreach(byte b; dg)
         app.put(format("%02x", b));

--- a/src/objectsystem.d
+++ b/src/objectsystem.d
@@ -1,11 +1,11 @@
 module objectsystem;
 
-import std.stdio;
-import std.string;
-import std.conv : to;
-import std.array;
-import std.algorithm;
-import std.file : write, readText, exists;
+import mstd.stdio;
+import mstd.string;
+import mstd.conv : to;
+import mstd.array;
+import mstd.algorithm;
+import mstd.file : write, readText, exists;
 import md5sum : hexDigest;
 
 struct Object {


### PR DESCRIPTION
## Summary
- rename local `std` package to `mstd`
- update all imports and references to use the new module names
- fix accidental double-replacement in interpreter and lferepl

## Testing
- `ldc2 -betterC --nodefaultlib -I=. -mtriple=x86_64-pc-linux-gnu src/*.d -of=interpreter` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6c4eafbc832781bb6a1e1a59dae8