### PR TITLE
Fix file rename import for D compiler

### DIFF
--- a/mstd/file.d
+++ b/mstd/file.d
@@ -98,7 +98,7 @@ void copy(string src, string dst)
 
 void rename(string src, string dst)
 {
-    import core.sys.posix.unistd : rename as posix_rename;
+    import core.sys.posix.unistd : posix_rename = rename;
     posix_rename(src.toStringz(), dst.toStringz());
 }
 


### PR DESCRIPTION
## Summary
- fix the import alias syntax in `mstd/file.d`

## Testing
- `ldc2 -betterC --nodefaultlib -I=. -mtriple=x86_64-pc-linux-gnu src/*.d -of=interpreter` *(fails: `ldc2: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f6ead9ef483278e5e62b2ccba7732