### PR TITLE
Add script for betterC build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ The implementation is intentionally small and demonstrates how one might begin t
 
 ## Building
 
-A D compiler such as `dmd` or `ldc2` is required. To cross compile for a specific target, supply the desired architecture flags to the compiler. For example:
+A D compiler such as `dmd` or `ldc2` is required. When targeting an environment
+without the full D runtime, modules that use unsupported features must be
+excluded. The helper script `build_betterc.sh` automatically filters these
+modules and compiles the interpreter only with the compatible sources:
 
 ```bash
-ldc2 -betterC --nodefaultlib -I=. -mtriple=<target> src/*.d -of=interpreter
+./build_betterc.sh
 ```
 
-Replace `<target>` with the appropriate triple for the operating system described in the `internetcomputer` repository.
+`build_betterc.sh` assumes `ldc2` is available on your `PATH` and uses the
+`x86_64-pc-linux-gnu` triple by default. Adjust the script if a different target
+is required.
 
 ## Usage
 

--- a/build_betterc.sh
+++ b/build_betterc.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Modules that use unsupported features (exceptions or std library)
+unsupported=$(grep -lE '\b(Exception|import std|try|catch|throw)\b' src/*.d | tr '\n' ' ')
+
+modules=""
+for f in src/*.d; do
+    base=$(basename "$f")
+    if [[ " $unsupported " != *" $f "* ]]; then
+        modules+="$f "
+    fi
+done
+
+# Always include the interpreter even if it was flagged as unsupported
+modules+="src/interpreter.d"
+
+echo "Compiling modules:" $modules
+ldc2 -betterC --nodefaultlib -I=. -mtriple=x86_64-pc-linux-gnu $modules -of=interpreter


### PR DESCRIPTION
## Summary
- add `build_betterc.sh` to exclude modules that depend on unsupported runtime features
- document the script in the README for building with `--betterC`

## Testing
- `./build_betterc.sh` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7212398c8327aae59dc607bbf215