### PR TITLE
Fix build script to skip example

### DIFF
--- a/build_betterc.sh
+++ b/build_betterc.sh
@@ -6,9 +6,15 @@ unsupported=$(grep -lE '\b(Exception|import std|try|catch|throw)\b' src/*.d | tr
 modules=""
 for f in src/*.d; do
     base=$(basename "$f")
-    if [[ " $unsupported " != *" $f "* ]]; then
-        modules+="$f "
+    # Skip modules flagged as unsupported
+    if [[ " $unsupported " == *" $f "* ]]; then
+        continue
     fi
+    # Skip demonstration program which depends on unsupported modules
+    if [[ "$base" == "example.d" ]]; then
+        continue
+    fi
+    modules+="$f "
 done
 
 # Always include the interpreter even if it was flagged as unsupported


### PR DESCRIPTION
## Summary
- ignore example.d when building with `build_betterc.sh`
- avoid including demonstration source that depends on unsupported modules

## Testing
- `./build_betterc.sh` *(fails: `ldc2: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f73bd8bac83279c51b4d938dcf77d