### PR TITLE
Fix build script import path

### DIFF
--- a/build_betterc.sh
+++ b/build_betterc.sh
@@ -21,4 +21,7 @@ done
 modules+="src/interpreter.d"
 
 echo "Compiling modules:" $modules
-ldc2 -betterC --nodefaultlib -I=. -mtriple=x86_64-pc-linux-gnu $modules -of=interpreter
+# Add the src directory to the import path so the compiler can locate
+# modules such as `dircolors` which live under src/ while declaring
+# a simple module name.
+ldc2 -betterC --nodefaultlib -I=. -Isrc -mtriple=x86_64-pc-linux-gnu $modules -of=interpreter


### PR DESCRIPTION
## Summary
- fix `build_betterc.sh` import path so ldc2 can find modules under `src`

## Testing
- `./build_betterc.sh` *(fails: `ldc2: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f76039cc883279e23e057d9f305e1