### PR TITLE
Switch to full D compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@ The implementation is intentionally small and demonstrates how one might begin t
 
 ## Building
 
-A D compiler such as `dmd` or `ldc2` is required. When targeting an environment
-without the full D runtime, modules that use unsupported features must be
-excluded. The helper script `build_betterc.sh` automatically filters these
-modules and compiles the interpreter only with the compatible sources:
+A D compiler such as `dmd` or `ldc2` is required. The interpreter can now be
+built with the full D runtime using the `build_full.sh` helper script:
 
 ```bash
-./build_betterc.sh
+./build_full.sh
 ```
 
-`build_betterc.sh` assumes `ldc2` is available on your `PATH` and uses the
-`x86_64-pc-linux-gnu` triple by default. Adjust the script if a different target
-is required.
+`build_full.sh` assumes `ldc2` is available on your `PATH`. Adjust the script if
+you prefer a different compiler or additional flags.
 
 ## Usage
 

--- a/build_full.sh
+++ b/build_full.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Compile all modules using the full D compiler.
+modules=$(ls src/*.d | tr '\n' ' ')
+
+echo "Compiling modules:" $modules
+
+ldc2 -I=. -Isrc $modules -of=interpreter


### PR DESCRIPTION
## Summary
- build interpreter with the full D runtime
- document new build script

## Testing
- `bash build_full.sh` *(fails: `ldc2` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c2ef4dfc8327a94ff6f904b66150