### PR TITLE
Use anonymos-dmd compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ The implementation is intentionally small and demonstrates how one might begin t
 
 ## Building
 
-A D compiler such as `dmd` or `ldc2` is required. The interpreter can now be
+A D compiler such as [`anonymos-dmd`](https://github.com/Jonathan-R-Anderson/anonymos-dmd) or `ldc2` is required. The interpreter can now be
 built with the full D runtime using the `build_full.sh` helper script:
 
 ```bash
 ./build_full.sh
 ```
 
-`build_full.sh` assumes `ldc2` is available on your `PATH`. Adjust the script if
-you prefer a different compiler or additional flags.
+`build_full.sh` will use `anonymos-dmd` by default. Set the `DC` environment
+variable to override the compiler if you prefer `ldc2` or another
+compatible D compiler.
 
 ## Usage
 

--- a/build_betterc.sh
+++ b/build_betterc.sh
@@ -24,4 +24,5 @@ echo "Compiling modules:" $modules
 # Add the src directory to the import path so the compiler can locate
 # modules such as `dircolors` which live under src/ while declaring
 # a simple module name.
-ldc2 -betterC --nodefaultlib -I=. -Isrc -mtriple=x86_64-pc-linux-gnu $modules -of=interpreter
+dmd_cmd=${DC:-anonymos-dmd}
+"$dmd_cmd" -betterC --nodefaultlib -I=. -Isrc -mtriple=x86_64-pc-linux-gnu $modules -of=interpreter

--- a/build_full.sh
+++ b/build_full.sh
@@ -6,4 +6,5 @@ modules=$(ls src/*.d | tr '\n' ' ')
 
 echo "Compiling modules:" $modules
 
-ldc2 -I=. -Isrc $modules -of=interpreter
+dmd_cmd=${DC:-anonymos-dmd}
+"$dmd_cmd" -I=. -Isrc $modules -of=interpreter


### PR DESCRIPTION
## Summary
- default to `anonymos-dmd` for building
- update README with new compiler instructions

## Testing
- `bash build_full.sh` *(fails: anonymos-dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a855ff3a0832792519bbf650c457f