### PR TITLE
Add installation script to use shell as login shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ built with the full D runtime using the `build_full.sh` helper script:
 `build_full.sh` will use `anonymos-dmd` by default. Set the `DC` environment
 variable to override the compiler if you prefer `ldc2` or another
 compatible D compiler.
+## Installing as a login shell
+
+To build and install the interpreter so it can be used as a login shell run:
+
+```bash
+./install.sh
+```
+
+This script builds the binary, copies it to /usr/local/bin/dshell, and ensures /etc/shells includes the new path so you can select it with `chsh`.
 
 ## Usage
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Install the custom D-based shell as a login shell
+set -e
+
+# Build the shell using the existing build script
+./build_full.sh
+
+# Determine install destination
+DEST="${PREFIX:-/usr/local/bin}"
+TARGET="$DEST/dshell"
+
+# Copy the built interpreter to the destination
+sudo install -m 755 interpreter "$TARGET"
+
+# Add the shell to /etc/shells if it is not already present
+if ! grep -qx "$TARGET" /etc/shells; then
+  echo "$TARGET" | sudo tee -a /etc/shells > /dev/null
+fi
+
+echo "Installed shell to $TARGET"
+echo "Use 'chsh -s $TARGET' to set it as your login shell."


### PR DESCRIPTION
## Summary
- provide `install.sh` to build and register the interpreter as a login shell
- document how to use the installation script in the README

## Testing
- `./build_full.sh` *(fails: anonymos-dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf810fb88327ba6e24f60c955559