### PR TITLE
feat: add linux build option and zsh compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,30 @@ The implementation is intentionally small and demonstrates how one might begin t
 ## Building
 
 A D compiler such as [`anonymos-dmd`](https://github.com/Jonathan-R-Anderson/anonymos-dmd) or `ldc2` is required. The interpreter can now be
-built with the full D runtime using the `build_full.sh` helper script:
+built with the full D runtime using the `build_full.sh` helper script.
+The build scripts accept the target system as the first argument or via
+the `SYSTEM` environment variable. Pass `linux` to build with the system
+`dmd` compiler instead of the custom one:
 
 ```bash
-./build_full.sh
+./build_full.sh linux       # or: SYSTEM=linux ./build_full.sh
 ```
 
-`build_full.sh` will use `anonymos-dmd` by default. Set the `DC` environment
-variable to override the compiler if you prefer `ldc2` or another
-compatible D compiler.
+If no system is specified the scripts fall back to `anonymos-dmd`.
+Set the `DC` environment variable to override the compiler if you prefer
+`ldc2` or another compatible D compiler.
 ## Installing as a login shell
 
 To build and install the interpreter so it can be used as a login shell run:
 
 ```bash
-./install.sh
+./install.sh linux     # or: SYSTEM=linux ./install.sh
 ```
 
-This script builds the binary, copies it to /usr/local/bin/dshell, and ensures /etc/shells includes the new path so you can select it with `chsh`.
+This script builds the binary, copies it to /usr/local/bin/dshell, and ensures
+/etc/shells includes the new path so you can select it with `chsh`.
+The build and install helpers are compatible with both Bash and Z shell
+environments.
 
 ## Usage
 

--- a/build_betterc.sh
+++ b/build_betterc.sh
@@ -1,4 +1,8 @@
+#!/usr/bin/env bash
 set -e
+
+# Determine target system from argument or SYSTEM env var
+system=${1:-${SYSTEM:-custom}}
 
 # Modules that use unsupported features (exceptions or std library)
 unsupported=$(grep -lE '\b(Exception|import std|try|catch|throw)\b' src/*.d | tr '\n' ' ')
@@ -24,5 +28,9 @@ echo "Compiling modules:" $modules
 # Add the src directory to the import path so the compiler can locate
 # modules such as `dircolors` which live under src/ while declaring
 # a simple module name.
-dmd_cmd=${DC:-anonymos-dmd}
+if [[ "$system" == "linux" ]]; then
+    dmd_cmd=${DC:-dmd}
+else
+    dmd_cmd=${DC:-anonymos-dmd}
+fi
 "$dmd_cmd" -betterC --nodefaultlib -I=. -Isrc -mtriple=x86_64-pc-linux-gnu $modules -of=interpreter

--- a/build_full.sh
+++ b/build_full.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 set -e
 
+# Determine target system from the first argument or SYSTEM env var
+system=${1:-${SYSTEM:-custom}}
+
 # Compile all modules using the full D compiler.
 modules=$(ls src/*.d | tr '\n' ' ')
 
 echo "Compiling modules:" $modules
 
-dmd_cmd=${DC:-anonymos-dmd}
+# Use the Linux system compiler when targeting a Linux host
+if [[ "$system" == "linux" ]]; then
+    dmd_cmd=${DC:-dmd}
+else
+    dmd_cmd=${DC:-anonymos-dmd}
+fi
+
 "$dmd_cmd" -I=. -Isrc $modules -of=interpreter

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,9 @@
 # Install the custom D-based shell as a login shell
 set -e
 
-# Build the shell using the existing build script
-./build_full.sh
+# Determine target system and build accordingly
+system=${1:-${SYSTEM:-custom}}
+./build_full.sh "$system"
 
 # Determine install destination
 DEST="${PREFIX:-/usr/local/bin}"


### PR DESCRIPTION
## Summary
- allow build scripts to target Linux and use the system `dmd` compiler
- accept target system in install script and document usage
- update docs noting bash and zsh compatibility

## Testing
- `bash build_full.sh linux` *(fails: dmd: command not found)*
- `bash build_betterc.sh linux` *(fails: dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d1fa004483278a84c341e1176338