### PR TITLE
Fix octal literal in mkdir wrapper

### DIFF
--- a/mstd/file.d
+++ b/mstd/file.d
@@ -119,7 +119,11 @@ string readLink(string path)
 /// Create a directory at ``path`` with the given ``mode`` (defaults to
 /// ``0777`` like the POSIX ``mkdir``).  This is a small wrapper around the
 /// POSIX call to keep the public API simple.
-void mkdir(string path, int mode = 0o777)
+///
+/// D's compiler version in this project does not support the ``0o`` prefix
+/// for octal literals, so we use the traditional leading ``0`` notation
+/// instead.
+void mkdir(string path, int mode = 0777)
 {
     posix_mkdir(path.toStringz(), mode);
 }


### PR DESCRIPTION
## Summary
- use leading-0 notation for default directory mode in `mstd.file.mkdir`
- note compiler limitation in comments

## Testing
- `./build_full.sh linux` *(fails: dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d6bc96508327830750654c4cce19