### PR TITLE
Expand minimal stdlib for shell

### DIFF
--- a/mstd/algorithm.d
+++ b/mstd/algorithm.d
@@ -1,16 +1,25 @@
 module mstd.algorithm;
 
+import mstd.string : indexOf;
+
 // Minimal implementations of selected std.algorithm utilities used in this project.
 
 /// Returns true if `elem` is present in range `r`.
 bool canFind(Range, Elem)(Range r, Elem elem)
 {
-    foreach(item; r)
+    static if (is(Range == string) && is(Elem == string))
     {
-        if(item == elem)
-            return true;
+        return indexOf(r, elem) != -1;
     }
-    return false;
+    else
+    {
+        foreach(item; r)
+        {
+            if(item == elem)
+                return true;
+        }
+        return false;
+    }
 }
 
 /// Filter elements of a range by predicate `pred`.

--- a/mstd/array.d
+++ b/mstd/array.d
@@ -5,16 +5,22 @@ module mstd.array;
 /// Simple dynamic array collector.
 struct Appender(T)
 {
-    T[] data;
+    T data;
 
-    /// Append a value.
+    /// Append an entire slice of values.
     void put(T value)
     {
         data ~= value;
     }
 
+    /// Append a single element.
+    void put(typeof(T.init[0]) value)
+    {
+        data ~= value;
+    }
+
     /// Retrieve the built array.
-    T[] array()
+    T array()
     {
         return data;
     }

--- a/mstd/regex.d
+++ b/mstd/regex.d
@@ -26,8 +26,14 @@ Regex regex(string pattern, string flags = "")
 
 struct Captures
 {
-    string hit;  /// matched substring
-    string pre;  /// prefix before the match
+    string hit;       /// matched substring
+    string pre;       /// prefix before the match
+    string[] captures;
+
+    bool empty()
+    {
+        return hit.length == 0 && pre.length == 0 && captures.length == 0;
+    }
 }
 
 /// Return the first match of ``r`` in ``input`` or ``Captures()`` if
@@ -38,8 +44,8 @@ Captures match(string input, Regex r)
     auto idx = indexOf(haystack, r.pattern);
     if(idx == -1)
         return Captures();
-    return Captures(input[idx .. idx + r.pattern.length],
-                    input[0 .. idx]);
+    auto hit = input[idx .. idx + r.pattern.length];
+    return Captures(hit, input[0 .. idx], [hit]);
 }
 
 /// Alias for ``match`` for compatibility with Phobos.

--- a/mstd/stdio.d
+++ b/mstd/stdio.d
@@ -2,6 +2,7 @@ module mstd.stdio;
 
 import core.stdc.stdio;
 import mstd.string : toStringz;
+import mstd.conv : to;
 
 alias File = FILE*;
 
@@ -9,15 +10,16 @@ alias stdin  = core.stdc.stdio.stdin;
 alias stdout = core.stdc.stdio.stdout;
 alias stderr = core.stdc.stdio.stderr;
 
-void writeln(string s)
-{
-    fwrite(s.ptr, 1, s.length, stdout);
-    fwrite("\n".ptr, 1, 1, stdout);
-}
-
 void write(string s)
 {
     fwrite(s.ptr, 1, s.length, stdout);
+}
+
+void writeln(T...)(T args)
+{
+    foreach(arg; args)
+        write(to!string(arg));
+    write("\n");
 }
 
 void writef(string fmt, string s)
@@ -31,5 +33,19 @@ void writefln(string fmt, ...)
 {
     vfprintf(stdout, fmt.toStringz(), _argptr);
     fwrite("\n".ptr, 1, 1, stdout);
+}
+
+string readln()
+{
+    char[] buf;
+    int c = fgetc(stdin);
+    if(c == EOF)
+        return null;
+    while(c != EOF && c != '\n')
+    {
+        buf ~= cast(char)c;
+        c = fgetc(stdin);
+    }
+    return cast(string)buf;
 }
 

--- a/mstd/string.d
+++ b/mstd/string.d
@@ -89,10 +89,15 @@ string[] splitLines(string s)
     return split(s, "\n");
 }
 
+char toLower(const char ch)
+{
+    return cast(char)((ch >= 'A' && ch <= 'Z') ? ch + 32 : ch);
+}
+
 string toLower(string s)
 {
     string result;
     foreach(ch; s)
-        result ~= cast(char) ((ch >= 'A' && ch <= 'Z') ? ch + 32 : ch);
+        result ~= toLower(ch);
     return result;
 }


### PR DESCRIPTION
## Summary
- Extend Appender to accept single elements and return built array directly
- Add char overload for toLower and reuse in string version
- Provide variadic writeln, simple readln, and substring-aware canFind
- Expose basic regex captures structure with empty check

## Testing
- `./install.sh linux` *(fails: dmd: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898959d5b648327ac2a04f4de18d3e9