### PR TITLE
Add generic conversion helpers and file utility tweaks

### DIFF
--- a/mstd/conv.d
+++ b/mstd/conv.d
@@ -11,25 +11,47 @@ class ConvException : Exception
     }
 }
 
-/// Convert string to integral/double types or return the string itself.
-T to(T)(string s)
+/// Generic conversion function similar to Phobos' ``std.conv.to``.  It
+/// supports converting strings to numeric types and numeric types to strings.
+/// Only a very small subset of conversions are implemented as required by the
+/// utilities in this repository.
+T to(T, S)(S value)
 {
-    static if (is(T == int))
-        return atoi(s.ptr);
-    else static if (is(T == long))
-        return strtoll(s.ptr, null, 10);
-    else static if (is(T == double))
-        return strtod(s.ptr, null);
+    // Conversions from strings
+    static if (is(S == string))
+    {
+        static if (is(T == int))
+            return atoi(value.ptr);
+        else static if (is(T == long))
+            return strtoll(value.ptr, null, 10);
+        else static if (is(T == double))
+            return strtod(value.ptr, null);
+        else static if (is(T == string))
+            return value;
+        else
+            static assert(false, "Unsupported conversion");
+    }
+    // Conversions to strings from integral types
     else static if (is(T == string))
-        return s;
+    {
+        char[64] buf;
+        size_t len;
+        static if (is(S == long) || is(S == int) || is(S == short) || is(S == byte))
+        {
+            len = sprintf(buf.ptr, "%lld", cast(long)value);
+        }
+        else static if (is(S == ulong) || is(S == uint) || is(S == ushort) || is(S == ubyte) || is(S == char) || is(S == wchar) || is(S == dchar))
+        {
+            len = sprintf(buf.ptr, "%llu", cast(ulong)value);
+        }
+        else
+        {
+            static assert(false, "Unsupported conversion");
+        }
+        return buf[0 .. len].idup;
+    }
     else
+    {
         static assert(false, "Unsupported conversion");
-}
-
-/// Convert integral types to string.
-string to(T)(T value) if (is(T : long))
-{
-    char[64] buf;
-    auto len = sprintf(buf.ptr, "%lld", cast(long)value);
-    return buf[0 .. len].idup;
+    }
 }

--- a/mstd/string.d
+++ b/mstd/string.d
@@ -7,7 +7,10 @@ const(char)* toStringz(string s)
     return s.ptr;
 }
 
-string[] split(string s, string delim)
+// ``split`` in the real Phobos library offers an overload that splits on
+// whitespace when no delimiter is provided.  Several utilities expect this
+// behaviour, so provide a default delimiter of a single space to emulate it.
+string[] split(string s, string delim = " ")
 {
     string[] result;
     size_t start = 0;

--- a/src/cal.d
+++ b/src/cal.d
@@ -1,6 +1,7 @@
 module cal;
 
 import mstd.stdio;
+import mstd.conv : to;
 
 bool isLeapYear(int year) {
     return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
@@ -43,7 +44,11 @@ void printMonth(int month, int year, bool mondayFirst=false) {
     int w = 0;
     foreach(i; 0 .. start) { write("   "); w++; }
     foreach(d; 1 .. days + 1) {
-        writef("%2d ", d);
+        // ``writef`` only accepts string arguments, so convert the day number
+        // explicitly before printing.  This mirrors the behaviour of the
+        // original implementation that relied on Phobos' more flexible
+        // formatting routines.
+        writef("%2s ", to!string(d));
         w++;
         if(w % 7 == 0)
             writeln();


### PR DESCRIPTION
## Summary
- Replace minimal conversion helpers with a generic `to` that converts between strings and numeric types
- Allow `mstd.string.split` to default to whitespace
- Track symlink status in `DirEntry` and provide a string-based `symlink` wrapper
- Fix calendar utility formatting by converting day numbers to strings

## Testing
- `./install.sh linux` *(fails: dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689898db447c83278794c4e5929433bc