### PR TITLE
Fix environment lookup and pattern parsing

### DIFF
--- a/src/crontab.d
+++ b/src/crontab.d
@@ -2,7 +2,7 @@ module crontab;
 
 import mstd.stdio;
 import mstd.file : readText, write, exists, remove;
-import mstd.process : environment;
+import mstd.process : environment, get;
 import core.stdc.stdlib : system;
 import mstd.string : startsWith, toStringz;
 

--- a/src/csplit.d
+++ b/src/csplit.d
@@ -21,16 +21,16 @@ Pattern parsePattern(string p) {
         pat.isRegex = true;
         pat.createFile = p[0] == '/';
         auto rest = p[1 .. $];
-        auto idx = rest.indexOf('/');
-        if(idx < 0) idx = rest.length;
+        auto idxInt = rest.indexOf('/');
+        size_t idx = idxInt < 0 ? rest.length : cast(size_t) idxInt;
         pat.regexStr = rest[0 .. idx];
         if(idx + 1 <= rest.length) {
-            auto off = rest[idx+1 .. $];
+            auto off = rest[idx + 1 .. $];
             if(off.length) pat.offset = to!int(off);
         }
     } else {
         pat.isRegex = false;
-        pat.lineNum = to!size_t(p);
+        pat.lineNum = cast(size_t) to!long(p);
     }
     return pat;
 }


### PR DESCRIPTION
## Summary
- import `get` helper for environment variable lookups in `crontab`
- guard regex parsing in `csplit` with `size_t` indexing and parse line numbers via `long`

## Testing
- `./install.sh linux` *(fails: dmd: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dmd` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68989d36fb4c8327820c9e160e82f1f2