### PR TITLE
Fix regex checks and size_t conversion

### DIFF
--- a/mstd/conv.d
+++ b/mstd/conv.d
@@ -24,6 +24,8 @@ T to(T, S)(S value)
             return atoi(value.ptr);
         else static if (is(T == long))
             return strtoll(value.ptr, null, 10);
+        else static if (is(T == ulong))
+            return cast(ulong)strtoll(value.ptr, null, 10);
         else static if (is(T == double))
             return strtod(value.ptr, null);
         else static if (is(T == string))

--- a/src/csplit.d
+++ b/src/csplit.d
@@ -38,7 +38,8 @@ Pattern parsePattern(string p) {
 size_t findRegex(string[] lines, size_t start, string re) {
     auto r = regex(re);
     foreach(i; start .. lines.length) {
-        if(matchFirst(lines[i], r)) return i;
+        auto m = matchFirst(lines[i], r);
+        if(!m.empty) return i;
     }
     return size_t.max; // not found
 }


### PR DESCRIPTION
## Summary
- ensure `csplit` checks regex matches correctly
- allow converting strings to `size_t` by supporting `ulong`

## Testing
- `./install.sh linux` *(fails: dmd: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898a661c2c083279aa64902ba4c52c0