### PR TITLE
Fix cut and date command modules

### DIFF
--- a/mstd/datetime.d
+++ b/mstd/datetime.d
@@ -17,3 +17,13 @@ SysTime unixTimeToStdTime(time_t t)
 {
     return t;
 }
+
+/// Convert ``t`` to an ISO-8601 extended format string using the local
+/// timezone.  This is a very small helper used by a few utilities.
+string toISOExtString(SysTime t)
+{
+    tm* info = localtime(&t);
+    char[20] buf;
+    auto len = strftime(buf.ptr, buf.length, "%Y-%m-%dT%H:%M:%S", info);
+    return buf[0 .. len].idup;
+}

--- a/src/cut.d
+++ b/src/cut.d
@@ -58,7 +58,7 @@ string cutBytes(string line, Range[] ranges) {
 string cutFields(string line, Range[] ranges, char delim, bool onlyDelim, string outDelim) {
     if(onlyDelim && line.indexOf(delim) < 0)
         return "";
-    auto fields = line.split(delim);
+    auto fields = line.split(to!string(delim));
     string[] outFields;
     foreach(i, f; fields) {
         if(inRanges(i+1, ranges)) outFields ~= f;
@@ -127,7 +127,7 @@ void cutCommand(string[] tokens) {
         idx++;
     }
 
-    if(outDelim.length == 0) outDelim = cast(string)delim;
+    if(outDelim.length == 0) outDelim = to!string(delim);
     if(useChars && !useBytes && charSpec.length) byteSpec = charSpec, useBytes=true;
     if(useFields && fieldSpec.length == 0) return; // nothing to select
     Range[] ranges;
@@ -152,7 +152,7 @@ void cutCommand(string[] tokens) {
         if(f == "-") {
             string line;
             while((line = readln()) !is null) {
-                auto l = line.stripRight("\n");
+                auto l = stripRight(line);
                 auto resultLine = processLine(l);
                 if(resultLine.length || !onlyDelim)
                     writeln(resultLine);

--- a/src/date.d
+++ b/src/date.d
@@ -1,91 +1,91 @@
 module date;
 
 import mstd.stdio;
-import mstd.datetime : Clock, SysTime, DateTime;
+import mstd.datetime : Clock, SysTime;
 import mstd.conv : to;
-import mstd.string : split;
+import mstd.string : split, startsWith;
 
-SysTime parseDateString(string s) {
-    try {
+import core.stdc.time : tm, mktime, gmtime, localtime, strftime;
+
+/// Parse a simple date string in the form "YYYY-MM-DD" or
+/// "YYYY-MM-DD HH:MM[:SS]" and return a `SysTime` value.  If parsing
+/// fails the current time is returned.
+SysTime parseDateString(string s)
+{
+    try
+    {
+        tm t;
+        t.tm_isdst = -1;
         auto parts = s.split(" ");
         auto date = parts[0].split("-");
-        if(date.length < 3) return Clock.currTime();
-        int year = to!int(date[0]);
-        int month = to!int(date[1]);
-        int day = to!int(date[2]);
-        int hour = 0, minute = 0, second = 0;
-        if(parts.length > 1) {
+        if (date.length < 3)
+            return Clock.currTime();
+        t.tm_year = to!int(date[0]) - 1900;
+        t.tm_mon = to!int(date[1]) - 1;
+        t.tm_mday = to!int(date[2]);
+        if (parts.length > 1)
+        {
             auto time = parts[1].split(":");
-            hour = to!int(time[0]);
-            if(time.length > 1) minute = to!int(time[1]);
-            if(time.length > 2) second = to!int(time[2]);
+            t.tm_hour = to!int(time[0]);
+            if (time.length > 1) t.tm_min = to!int(time[1]);
+            if (time.length > 2) t.tm_sec = to!int(time[2]);
         }
-        auto dt = DateTime(year, month, day, hour, minute, second);
-        return SysTime(dt);
-    } catch(Exception) {
+        return cast(SysTime)mktime(&t);
+    }
+    catch (Exception)
+    {
         return Clock.currTime();
     }
 }
 
-string two(int n) {
-    return n < 10 ? "0" ~ to!string(n) : to!string(n);
+/// Format ``t`` according to ``fmt`` using either local time or UTC
+/// representation depending on ``utc``.
+string formatDate(SysTime t, string fmt, bool utc)
+{
+    tm* info = utc ? gmtime(&t) : localtime(&t);
+    char[128] buf;
+    auto len = strftime(buf.ptr, buf.length, fmt.ptr, info);
+    return buf[0 .. len].idup;
 }
 
-string four(int n) {
-    if(n < 10) return "000" ~ to!string(n);
-    if(n < 100) return "00" ~ to!string(n);
-    if(n < 1000) return "0" ~ to!string(n);
-    return to!string(n);
-}
-
-string formatDate(SysTime t, string fmt) {
-    string result;
-    for(size_t i=0; i<fmt.length; ++i) {
-        if(fmt[i] == '%' && i + 1 < fmt.length) {
-            auto c = fmt[i+1];
-            switch(c) {
-                case '%': result ~= "%"; break;
-                case 'Y': result ~= four(t.year); break;
-                case 'm': result ~= two(t.month); break;
-                case 'd': result ~= two(t.day); break;
-                case 'H': result ~= two(t.hour); break;
-                case 'M': result ~= two(t.minute); break;
-                case 'S': result ~= two(t.second); break;
-                case 'F': result ~= four(t.year) ~ "-" ~ two(t.month) ~ "-" ~ two(t.day); break;
-                case 'T': result ~= two(t.hour) ~ ":" ~ two(t.minute) ~ ":" ~ two(t.second); break;
-                default: result ~= "%" ~ c; break;
-            }
-            i++;
-        } else {
-            result ~= fmt[i];
-        }
-    }
-    return result;
-}
-
-void dateCommand(string[] tokens) {
+/// Implementation of the ``date`` command.  Supports a minimal subset of
+/// the real utility's options sufficient for the uses within this
+/// repository.
+void dateCommand(string[] tokens)
+{
     SysTime time = Clock.currTime();
     bool utc = false;
-    string fmt = "%c";
+    string fmt;
     size_t idx = 1;
-    while(idx < tokens.length) {
+    while (idx < tokens.length)
+    {
         auto t = tokens[idx];
-        if(t == "-u" || t == "--utc" || t == "--universal") {
+        if (t == "-u" || t == "--utc" || t == "--universal")
+        {
             utc = true;
-        } else if(t.startsWith("--date=")) {
+        }
+        else if (t.startsWith("--date="))
+        {
             time = parseDateString(t[7 .. $]);
-        } else if(t == "-d" && idx + 1 < tokens.length) {
-            time = parseDateString(tokens[idx+1]);
+        }
+        else if (t == "-d" && idx + 1 < tokens.length)
+        {
+            time = parseDateString(tokens[idx + 1]);
             idx++;
-        } else if(t.length > 0 && t[0] == '+') {
+        }
+        else if (t.length > 0 && t[0] == '+')
+        {
             fmt = t[1 .. $];
         }
         idx++;
     }
-    if(utc) time = time.toUTC();
-    if(fmt == "%c")
-        writeln(time.toISOExtString());
+
+    if (fmt.length == 0)
+        fmt = "%c";
+
+    if (fmt == "%c")
+        writeln(formatDate(time, "%Y-%m-%dT%H:%M:%S", utc));
     else
-        writeln(formatDate(time, fmt));
+        writeln(formatDate(time, fmt, utc));
 }
 


### PR DESCRIPTION
## Summary
- correct cut module to handle char delimiters with string functions
- reimplement date command using C time functions and add ISO formatting helper

## Testing
- `./install.sh linux` *(fails: dmd: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898a78ab4988327a4fd6490ac3f298b