### PR TITLE
Fix import alias in conversion module

### DIFF
--- a/mstd/conv.d
+++ b/mstd/conv.d
@@ -3,7 +3,7 @@ module mstd.conv;
 import core.stdc.stdlib : atoi, strtol, strtoll, strtod;
 import core.stdc.stdio : sprintf;
 import std.bigint : BigInt;
-import std.conv : to as stdTo;
+import std.conv : stdTo = to;
 
 class ConvException : Exception
 {


### PR DESCRIPTION
## Summary
- use correct alias syntax for `std.conv.to` in `mstd/conv`.

## Testing
- `./install.sh linux` *(fails: dmd not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898b4422450832787b9d1a9ff1aef03