### PR TITLE
Fix imports and switch issues to enable compilation

### DIFF
--- a/src/df.d
+++ b/src/df.d
@@ -2,7 +2,10 @@ module df;
 
 import mstd.stdio;
 import mstd.file : readText;
-import mstd.string : split, toStringz;
+// Additional string utilities used throughout this module
+// `splitLines` is needed to iterate over /proc/mounts and `startsWith`
+// is used for option parsing below.
+import mstd.string : split, toStringz, splitLines, startsWith;
 import mstd.algorithm : canFind;
 import mstd.format : format;
 import mstd.conv : to;

--- a/src/diff.d
+++ b/src/diff.d
@@ -2,8 +2,10 @@ module diff;
 
 import mstd.stdio;
 import mstd.file : readText;
-import mstd.string : splitLines, toLower, strip, join, split;
-import mstd.algorithm : max;
+// String utilities plus `startsWith` for option parsing.
+import mstd.string : splitLines, toLower, strip, join, split, startsWith;
+// Algorithm helpers used for mapping and filtering ranges.
+import mstd.algorithm : max, map, filter;
 import mstd.array : array;
 
 struct DiffOp {
@@ -31,7 +33,14 @@ string normalize(string line, bool ignoreCase, bool ignoreSpace, bool ignoreBlan
 {
     auto l = line;
     if(ignoreSpace)
-        l = l.split.whitespace.join(" ").strip;
+    {
+        // Collapse runs of whitespace into a single space.  `split` defaults to
+        // splitting on a space, so remove empty segments to handle multiple
+        // spaces before joining them back together.
+        auto parts = l.split();
+        auto filtered = parts.filter!(p => p.length > 0);
+        l = filtered.join(" ").strip;
+    }
     if(ignoreBlank && l.length == 0)
         l = "";
     if(ignoreCase)
@@ -121,7 +130,6 @@ void diffFiles(string f1, string f2,
             case ' ': if(unified) writeln(" " ~ op.line); break;
             case '+': writeln(unified?"+" ~ op.line:"> " ~ op.line); break;
             case '-': writeln(unified?"-" ~ op.line:"< " ~ op.line); break;
-            default: break;
         }
     }
 }

--- a/src/dircolors.d
+++ b/src/dircolors.d
@@ -2,7 +2,8 @@ module dircolors;
 
 import mstd.stdio;
 import mstd.file : readText;
-import mstd.string : splitLines, strip, join;
+// Use `startsWith` for option parsing in addition to basic string helpers.
+import mstd.string : splitLines, strip, join, startsWith;
 import mstd.algorithm : filter, map;
 
 immutable string defaultDB = `

--- a/src/dmesg.d
+++ b/src/dmesg.d
@@ -1,7 +1,8 @@
 module dmesg;
 
 import mstd.stdio;
-import mstd.string : join;
+// `join` and `toStringz` help construct arguments for the C `system` call.
+import mstd.string : join, toStringz;
 import core.stdc.stdlib : system;
 
 /// Execute the system dmesg command with the provided arguments.
@@ -9,7 +10,7 @@ void dmesgCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "dmesg" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd);
+    auto rc = system(cmd.toStringz());
     if(rc != 0)
         writeln("dmesg failed with code ", rc);
 }

--- a/src/dos2unix.d
+++ b/src/dos2unix.d
@@ -2,7 +2,8 @@ module dos2unix;
 
 import mstd.stdio;
 import mstd.file : readText, write;
-import mstd.string : replace;
+// `replace` for line ending conversion and `startsWith` for option parsing.
+import mstd.string : replace, startsWith;
 
 void convertFile(string inFile, string outFile, bool keepDate, bool quiet)
 {

--- a/src/dparser.d
+++ b/src/dparser.d
@@ -3,6 +3,7 @@ module dparser;
 import mstd.stdio;
 import mstd.array : array;
 import mstd.algorithm;
+import mstd.conv : to;
 import dlexer;
 
 alias Action = long delegate(long, long);
@@ -42,7 +43,6 @@ class Parser {
             final switch (op.type) {
                 case "PLUS":  value += rhs; break;
                 case "MINUS": value -= rhs; break;
-                default: break;
             }
         }
         return value;
@@ -56,7 +56,6 @@ class Parser {
             final switch (op.type) {
                 case "TIMES":  value *= rhs; break;
                 case "DIVIDE": value /= rhs; break;
-                default: break;
             }
         }
         return value;


### PR DESCRIPTION
## Summary
- include missing string utilities like `startsWith` and `splitLines`
- add algorithm helpers and clean up whitespace normalization in `diff`
- remove invalid `default` cases in final switches and add `to` conversion
- ensure `system` call uses `toStringz`

## Testing
- `./build_full.sh linux` *(fails: dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898b5053a2083278c29973c79644b9b