### PR TITLE
Fix regex type instantiation and process import

### DIFF
--- a/src/crontab.d
+++ b/src/crontab.d
@@ -2,7 +2,7 @@ module crontab;
 
 import std.stdio;
 import std.file : readText, write, exists, remove;
-import std.process : environment, get;
+import std.process : environment;
 import core.stdc.stdlib : system;
 import std.string : startsWith, toStringz;
 

--- a/src/dlexer.d
+++ b/src/dlexer.d
@@ -13,7 +13,7 @@ struct Token {
 /// Defines a single tokenization rule.
 struct Rule {
     string name;
-    Regex pattern;
+    Regex!char pattern;
 }
 
 /// Simple regex-based lexer inspired by Python's SLY.


### PR DESCRIPTION
## Summary
- Fix lexer Rule to instantiate `Regex` with `char`
- Remove nonexistent `get` import from `std.process`

## Testing
- `./build_full.sh` *(fails: dmd: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898cb6036588327900590db1429cb2a