### PR TITLE
Fix import usage and string handling in D utilities

### DIFF
--- a/src/egrep.d
+++ b/src/egrep.d
@@ -54,7 +54,7 @@ void egrepCommand(string[] tokens)
         try {
             foreach(line; readText(f).splitLines) {
                 auto m = matchFirst(ignoreCase ? line.toLower : line, re);
-                bool matched = m !is null;
+                bool matched = !m.empty;
                 if(invert) matched = !matched;
                 if(matched) {
                     count++;

--- a/src/fdisk.d
+++ b/src/fdisk.d
@@ -92,7 +92,7 @@ void fdiskCommand(string[] tokens)
     if(optList) {
         if(args.length == 0) {
             foreach(entry; dirEntries("/sys/block", SpanMode.shallow))
-                args ~= "/dev/" ~ entry.name.split("/").back;
+                args ~= "/dev/" ~ entry.name.split("/")[$-1];
         }
         foreach(dev; args)
             listDevice(dev);

--- a/src/fgrep.d
+++ b/src/fgrep.d
@@ -2,8 +2,8 @@ module fgrep;
 
 import std.stdio;
 import std.file : readText;
-import std.algorithm.searching : canFind;
-import std.string : toLower;
+import std.algorithm : canFind, startsWith;
+import std.string : toLower, splitLines;
 import std.conv : to;
 
 void fgrepCommand(string[] tokens)

--- a/src/find.d
+++ b/src/find.d
@@ -3,7 +3,7 @@ module find;
 import std.stdio;
 import std.file : dirEntries, SpanMode, isFile, isDir;
 import std.path : baseName, buildPath;
-import std.algorithm : canFind;
+import std.algorithm : startsWith;
 import std.path : globMatch;
 import std.conv : to;
 

--- a/src/fmt.d
+++ b/src/fmt.d
@@ -1,10 +1,11 @@
 module fmt;
 
 import std.stdio;
-import std.string : split, splitLines, strip, join;
+import std.string : split, splitLines, strip, join, stripRight;
 import std.file : readText;
 import std.conv : to;
 import std.ascii : isDigit;
+import std.algorithm : startsWith, count;
 
 string[] formatParagraph(string para, size_t width)
 {

--- a/src/fold.d
+++ b/src/fold.d
@@ -4,6 +4,7 @@ import std.stdio;
 import std.file : readText;
 import std.string : splitLines, lastIndexOf, stripRight;
 import std.conv : to;
+import std.algorithm : startsWith;
 
 void foldLine(string line, size_t width, bool breakSpaces)
 {

--- a/src/fsck.d
+++ b/src/fsck.d
@@ -1,7 +1,7 @@
 module fsck;
 
 import std.stdio;
-import std.string : join;
+import std.string : join, toStringz;
 import core.stdc.stdlib : system;
 
 /// Execute the system fsck command with the provided arguments.
@@ -9,7 +9,7 @@ void fsckCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "fsck" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd);
+    auto rc = system(cmd.toStringz);
     if(rc != 0)
         writeln("fsck failed with code ", rc);
 }

--- a/src/fuser.d
+++ b/src/fuser.d
@@ -1,11 +1,13 @@
 module fuser;
 
 import std.stdio;
-import std.file : dirEntries, readLink, exists;
+import std.file : dirEntries, readLink, exists, SpanMode;
 import std.path : baseName, buildPath;
 import core.sys.posix.signal : kill, SIGKILL;
 import std.conv : to;
 import core.sys.posix.unistd : getpid;
+import std.string : strip, toLower;
+import std.algorithm : startsWith;
 
 /// List processes using a given file. Supports -k to kill them.
 void fuserCommand(string[] tokens)

--- a/src/getfacl.d
+++ b/src/getfacl.d
@@ -1,7 +1,7 @@
 module getfacl;
 
 import std.stdio;
-import std.string : join;
+import std.string : join, toStringz;
 import core.stdc.stdlib : system;
 
 /// Execute the system getfacl command with the provided arguments.
@@ -9,7 +9,7 @@ void getfaclCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "getfacl" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd);
+    auto rc = system(cmd.toStringz);
     if(rc != 0)
         writeln("getfacl failed with code ", rc);
 }

--- a/src/getopts.d
+++ b/src/getopts.d
@@ -1,7 +1,7 @@
 module getopts;
 
 import std.stdio;
-import std.string : strip;
+import std.string : strip, indexOf;
 import std.conv : to;
 
 extern __gshared string[string] variables; // from interpreter
@@ -44,7 +44,7 @@ void getoptsCommand(string[] tokens)
     auto pos = optstring.indexOf(opt);
     if(pos == -1) {
         variables[name] = "?";
-        variables["OPTARG"] = opt;
+        variables["OPTARG"] = to!string(opt);
         optind++;
         variables["OPTIND"] = to!string(optind);
         return;


### PR DESCRIPTION
## Summary
- include missing imports for string algorithms across utilities
- adapt system command helpers to use proper string conversions
- fix egrep, fdisk and other builtins' string handling

## Testing
- `ldc2 src/*.d -of=interpreter` *(fails: system symbol issues in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_689905fe9c048327bfde076479d3510d