### PR TITLE
Wrap system calls and replace parallel task execution

### DIFF
--- a/src/cron.d
+++ b/src/cron.d
@@ -3,10 +3,10 @@ module cron;
 import std.stdio;
 import std.file : readText, exists;
 import std.datetime : Clock, SysTime;
-import core.stdc.stdlib : system;
+import syswrap : system;
 import std.conv : to;
 import std.algorithm : splitter;
-import std.string : split, indexOf, strip, startsWith, join, splitLines, toStringz;
+import std.string : split, indexOf, strip, startsWith, join, splitLines;
 import core.thread : Thread;
 import core.time : dur;
 
@@ -88,7 +88,7 @@ void runCron(string path) {
                    job.dom[now.day] &&
                    job.months[now.month] &&
                    job.dow[now.dayOfWeek]) {
-                   system(job.cmd.toStringz);
+                   system(job.cmd);
                 }
             }
         }

--- a/src/crontab.d
+++ b/src/crontab.d
@@ -3,8 +3,8 @@ module crontab;
 import std.stdio;
 import std.file : readText, write, exists, remove;
 import std.process : environment;
-import core.stdc.stdlib : system;
-import std.string : startsWith, toStringz;
+import syswrap : system;
+import std.string : startsWith;
 
 void editFile(string path)
 {
@@ -15,7 +15,7 @@ void editFile(string path)
         editor = e2;
     else
         editor = "vi";
-    system((editor ~ " " ~ path).toStringz);
+    system(editor ~ " " ~ path);
 }
 
 void installFile(string src, string dest)

--- a/src/dmesg.d
+++ b/src/dmesg.d
@@ -2,14 +2,14 @@ module dmesg;
 
 import std.stdio;
 import std.string : join, toStringz;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system dmesg command with the provided arguments.
 void dmesgCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "dmesg" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd.toStringz);
+    auto rc = system(cmd);
     if(rc != 0)
         writeln("dmesg failed with code ", rc);
 }

--- a/src/eject.d
+++ b/src/eject.d
@@ -2,14 +2,14 @@ module eject;
 
 import std.stdio;
 import std.string : join, toStringz;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system eject command with the provided arguments.
 void ejectCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "eject" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd.toStringz);
+    auto rc = system(cmd);
     if(rc != 0)
         writeln("eject failed with code ", rc);
 }

--- a/src/fdformat.d
+++ b/src/fdformat.d
@@ -2,7 +2,7 @@ module fdformat;
 
 import std.stdio;
 import std.string : join, toStringz;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system fdformat command with the provided arguments.
 void fdformatCommand(string[] tokens)
@@ -13,7 +13,7 @@ void fdformatCommand(string[] tokens)
     }
     string args = tokens[1 .. $].join(" ");
     string cmd = "fdformat" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd.toStringz);
+    auto rc = system(cmd);
     if(rc != 0)
         writeln("fdformat failed with code ", rc);
 }

--- a/src/fsck.d
+++ b/src/fsck.d
@@ -2,14 +2,14 @@ module fsck;
 
 import std.stdio;
 import std.string : join, toStringz;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system fsck command with the provided arguments.
 void fsckCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "fsck" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd.toStringz);
+    auto rc = system(cmd);
     if(rc != 0)
         writeln("fsck failed with code ", rc);
 }

--- a/src/getfacl.d
+++ b/src/getfacl.d
@@ -2,14 +2,14 @@ module getfacl;
 
 import std.stdio;
 import std.string : join, toStringz;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system getfacl command with the provided arguments.
 void getfaclCommand(string[] tokens)
 {
     string args = tokens.length > 1 ? tokens[1 .. $].join(" ") : "";
     string cmd = "getfacl" ~ (args.length ? " " ~ args : "");
-    auto rc = system(cmd.toStringz);
+    auto rc = system(cmd);
     if(rc != 0)
         writeln("getfacl failed with code ", rc);
 }

--- a/src/groupadd.d
+++ b/src/groupadd.d
@@ -2,7 +2,7 @@ module groupadd;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system groupadd command with the provided arguments.
 void groupaddCommand(string[] tokens)

--- a/src/groupdel.d
+++ b/src/groupdel.d
@@ -2,7 +2,7 @@ module groupdel;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system groupdel command with the provided arguments.
 void groupdelCommand(string[] tokens)

--- a/src/groupmod.d
+++ b/src/groupmod.d
@@ -2,7 +2,7 @@ module groupmod;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system groupmod command with the provided arguments.
 void groupmodCommand(string[] tokens)

--- a/src/groups.d
+++ b/src/groups.d
@@ -2,7 +2,7 @@ module groups;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system groups command with the provided arguments.
 void groupsCommand(string[] tokens)

--- a/src/gzip.d
+++ b/src/gzip.d
@@ -2,7 +2,7 @@ module gzip;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system gzip command with the provided arguments.
 void gzipCommand(string[] tokens)

--- a/src/iconv.d
+++ b/src/iconv.d
@@ -2,7 +2,7 @@ module iconv;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system iconv command with the provided arguments.
 void iconvCommand(string[] tokens)

--- a/src/id.d
+++ b/src/id.d
@@ -2,7 +2,7 @@ module id;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system id command with the provided arguments.
 void idCommand(string[] tokens)

--- a/src/ifcmd.d
+++ b/src/ifcmd.d
@@ -2,7 +2,7 @@ module ifcmd;
 
 import std.stdio;
 import std.string : join, replace;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Evaluate a shell if statement using /bin/sh.
 void ifCommand(string[] tokens)

--- a/src/ifconfig.d
+++ b/src/ifconfig.d
@@ -2,7 +2,7 @@ module ifconfig;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system ifconfig command with the provided arguments.
 void ifconfigCommand(string[] tokens)

--- a/src/ifdown.d
+++ b/src/ifdown.d
@@ -2,7 +2,7 @@ module ifdown;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system ifdown command with the provided arguments.
 void ifdownCommand(string[] tokens)

--- a/src/ifup.d
+++ b/src/ifup.d
@@ -2,7 +2,7 @@ module ifup;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system ifup command with the provided arguments.
 void ifupCommand(string[] tokens)

--- a/src/importcmd.d
+++ b/src/importcmd.d
@@ -2,7 +2,7 @@ module importcmd;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system import command with the provided arguments.
 void importCommand(string[] tokens)

--- a/src/install.d
+++ b/src/install.d
@@ -2,7 +2,7 @@ module install;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system install command with the provided arguments.
 void installCommand(string[] tokens)

--- a/src/iostat.d
+++ b/src/iostat.d
@@ -2,7 +2,7 @@ module iostat;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system iostat command with the provided arguments.
 void iostatCommand(string[] tokens)

--- a/src/ip.d
+++ b/src/ip.d
@@ -2,7 +2,7 @@ module ip;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system ip command with the provided arguments.
 void ipCommand(string[] tokens)

--- a/src/join.d
+++ b/src/join.d
@@ -2,7 +2,7 @@ module join;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system join command with the provided arguments.
 void joinCommand(string[] tokens)

--- a/src/kill.d
+++ b/src/kill.d
@@ -2,7 +2,7 @@ module kill;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system kill command with the provided arguments.
 void killCommand(string[] tokens)

--- a/src/killall.d
+++ b/src/killall.d
@@ -2,7 +2,7 @@ module killall;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system killall command with the provided arguments.
 void killallCommand(string[] tokens)

--- a/src/klist.d
+++ b/src/klist.d
@@ -2,7 +2,7 @@ module klist;
 
 import std.stdio;
 import std.string : join;
-import core.stdc.stdlib : system;
+import syswrap : system;
 
 /// Execute the system klist command with the provided arguments.
 void klistCommand(string[] tokens)

--- a/src/lferepl.d
+++ b/src/lferepl.d
@@ -11,11 +11,11 @@ import std.array;
 import std.conv : to;
 import std.utf;
 import std.file : readText, copy;
-import std.parallelism;
+import core.thread : Thread;
 import cpio : createArchive, extractArchive;
 import core.sync.mutex : Mutex;
 import core.sync.condition : Condition;
-import core.stdc.stdlib : system;
+import syswrap : system;
 version(Posix) import core.sys.posix.unistd : execvp;
 import objectsystem;
 import local;
@@ -1013,7 +1013,7 @@ Value evalList(Expr e) {
             cur.links ~= pid;
             proc.links ~= currentPid;
         }
-        taskPool.put(() {
+        auto thr = new Thread({
             currentPid = pid;
             Value reason = atomVal("normal");
             try {
@@ -1025,6 +1025,7 @@ Value evalList(Expr e) {
             }
             propagateExit(pid, reason);
         });
+        thr.start();
         return atomVal(pid);
     } else if(head == "process_flag") {
         auto flagVal = evalExpr(e.list[1]);

--- a/src/syswrap.d
+++ b/src/syswrap.d
@@ -1,0 +1,8 @@
+module syswrap;
+
+import std.string : toStringz;
+import core.stdc.stdlib : c_system = system;
+
+int system(string cmd) {
+    return c_system(cmd.toStringz);
+}


### PR DESCRIPTION
## Summary
- add `syswrap` helper module that converts string commands to C-compatible system calls
- switch interpreter parallel execution to thread-based model and alias `join` module
- adjust LFErEPL process spawning to use threads

## Testing
- `ldc2 src/*.d -of=interpreter` *(fails: switch statement without default, multiple undefined identifiers)*

------
https://chatgpt.com/codex/tasks/task_e_689a09b955988327a68de47c14f4b93b