### PR TITLE
Fix compilation errors across multiple modules

### DIFF
--- a/src/getopts.d
+++ b/src/getopts.d
@@ -3,8 +3,7 @@ module getopts;
 import std.stdio;
 import std.string : strip, indexOf;
 import std.conv : to;
-
-extern __gshared string[string] variables; // from interpreter
+import interpreter : variables;
 
 /// Simplified getopts implementation.
 void getoptsCommand(string[] tokens)

--- a/src/interpreter.d
+++ b/src/interpreter.d
@@ -330,6 +330,9 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             case "-": result = a - b; break;
             case "*": result = a * b; break;
             case "/": result = b == 0 ? 0 : a / b; break;
+            default:
+                writeln("Unknown operator " ~ op);
+                break;
         }
         writeln(result);
     } else if(op == "bc") {
@@ -1444,10 +1447,9 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
             if(bgJobs.length == 0) {
                 writeln("bg: no current job");
             } else {
-                auto ref job = bgJobs[$-1];
-                if(!job.running) {
-                    job.running = true;
-                    job.thread.start();
+                if(!bgJobs[$-1].running) {
+                    bgJobs[$-1].running = true;
+                    bgJobs[$-1].thread.start();
                 }
             }
         } else if(tokens[1].startsWith("%")) {
@@ -1750,14 +1752,15 @@ void runCommand(string cmd, bool skipAlias=false, size_t callLine=0, string call
                 bool local = false;
                 auto lowerLine = line.toLower;
                 auto lowerKw = kw.toLower;
-                if(useRegex) {
-                    try {
-                        auto r = regex(lowerKw, "i");
-                        local = matchFirst(lowerLine, r) !is null;
-                    } catch(Exception) {
-                        continue;
-                    }
-                } else if(useWildcard) {
+                  if(useRegex) {
+                      try {
+                          auto r = regex(lowerKw, "i");
+                          auto m = matchFirst(lowerLine, r);
+                          local = !m.empty;
+                      } catch(Exception) {
+                          continue;
+                      }
+                  } else if(useWildcard) {
                     local = globMatch(lowerLine, lowerKw);
                 } else if(useExact) {
                     foreach(word; lowerLine.split()) {

--- a/src/less.d
+++ b/src/less.d
@@ -3,6 +3,7 @@ module less;
 import std.stdio;
 import std.file : readText;
 import std.algorithm : min;
+import std.string : splitLines, strip;
 
 /// Very small pager implementation.
 void lessCommand(string[] tokens)

--- a/src/letcmd.d
+++ b/src/letcmd.d
@@ -1,11 +1,10 @@
 module letcmd;
 
 import std.stdio;
-import std.string : split, replace;
+import std.string : split, replace, indexOf;
 import std.conv : to;
 import bc : bcEval;
-
-extern __gshared string[string] variables;
+import interpreter : variables;
 
 /// Evaluate arithmetic expressions and assign to variables.
 void letCommand(string[] tokens)

--- a/src/lfe.d
+++ b/src/lfe.d
@@ -5,6 +5,8 @@ import dparser;
 import std.regex : regex;
 import std.stdio;
 import std.string;
+import std.algorithm : map, filter;
+import std.array : join, array;
 
 struct Expr {
     bool isList;

--- a/src/linkcmd.d
+++ b/src/linkcmd.d
@@ -1,6 +1,7 @@
 module linkcmd;
 
 import std.stdio;
+import std.string : toStringz;
 import core.sys.posix.unistd : link;
 
 /// Create a hard link.
@@ -13,7 +14,7 @@ void linkCommand(string[] tokens)
     auto src = tokens[1];
     auto dest = tokens[2];
     try {
-        link(src, dest);
+        link(toStringz(src), toStringz(dest));
     } catch(Exception) {
         writeln("link: cannot link ", src, " to ", dest);
     }

--- a/src/ln.d
+++ b/src/ln.d
@@ -4,6 +4,7 @@ import std.stdio;
 import std.file : remove, exists, isDir;
 import core.sys.posix.unistd : link, symlink;
 import std.path : baseName, buildPath;
+import std.string : startsWith, toStringz;
 
 /// Simplified ln implementation supporting -s, -f and -v.
 void lnCommand(string[] tokens)
@@ -14,11 +15,11 @@ void lnCommand(string[] tokens)
     size_t idx = 1;
     while(idx < tokens.length && tokens[idx].startsWith("-")) {
         auto t = tokens[idx];
-        if(t == "-s" || t == "--symbolic") symbolic = true;
-        else if(t == "-f" || t == "--force") force = true;
-        else if(t == "-v" || t == "--verbose") verbose = true;
-        else if(t == "--") { idx++; break; }
-        else break;
+            if(t == "-s" || t == "--symbolic") symbolic = true;
+            else if(t == "-f" || t == "--force") force = true;
+            else if(t == "-v" || t == "--verbose") verbose = true;
+            else if(t == "--") { idx++; break; }
+            else break;
         idx++;
     }
     auto files = tokens[idx .. $];
@@ -30,21 +31,21 @@ void lnCommand(string[] tokens)
     bool destIsDir = false;
     if(files.length > 2) destIsDir = true;
     else destIsDir = isDir(dest);
-    foreach(src; files[0 .. $-1]) {
-        string target = destIsDir ? buildPath(dest, baseName(src)) : dest;
-        if(force && exists(target)) {
-            try remove(target); catch(Exception) {}
+        foreach(src; files[0 .. $-1]) {
+            string target = destIsDir ? buildPath(dest, baseName(src)) : dest;
+            if(force && exists(target)) {
+                try remove(target); catch(Exception) {}
+            }
+            try {
+                if(symbolic)
+                    symlink(toStringz(src), toStringz(target));
+                else
+                    link(toStringz(src), toStringz(target));
+                if(verbose)
+                    writeln(src, " -> ", target);
+            } catch(Exception) {
+                writeln("ln: failed to link ", src, " to ", target);
+            }
         }
-        try {
-            if(symbolic)
-                symlink(src, target);
-            else
-                link(src, target);
-            if(verbose)
-                writeln(src, " -> ", target);
-        } catch(Exception) {
-            writeln("ln: failed to link ", src, " to ", target);
-        }
-    }
 }
 

--- a/src/local.d
+++ b/src/local.d
@@ -1,11 +1,10 @@
 module local;
 
 import std.stdio;
+import std.string : indexOf;
+import interpreter : variables;
 
 /// Minimal local implementation - assigns variables in the global map.
-extern (C) {
-    __gshared string[string] variables;
-}
 
 void localCommand(string[] tokens)
 {

--- a/src/look.d
+++ b/src/look.d
@@ -1,11 +1,13 @@
 module look;
 
 import std.stdio;
-import std.string : toLower, strip;
+import std.string : toLower, strip, startsWith, indexOf, chomp;
 import std.file : readText;
 import std.stdio : File;
 import std.algorithm : filter;
+import std.array : array;
 import std.ascii : isAlphaNum;
+import std.conv : to;
 
 void lookCommand(string[] tokens)
 {
@@ -15,7 +17,7 @@ void lookCommand(string[] tokens)
     bool useTerm = false;
 
     size_t idx = 1;
-    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+      while(idx < tokens.length && tokens[idx].startsWith("-")) {
         auto t = tokens[idx];
         if(t == "-d") dict = true;
         else if(t == "-f") ignoreCase = true;
@@ -33,11 +35,11 @@ void lookCommand(string[] tokens)
     string prefix = tokens[idx++];
     string file = idx < tokens.length ? tokens[idx] : "/usr/share/dict/words";
 
-    File f;
-    try { f = File(file, "r"); } catch(Exception) { writeln("look: cannot read ", file); return; }
+      File f;
+      try { f = File(file, "r"); } catch(Exception) { writeln("look: cannot read ", file); return; }
 
-    foreach(line; f.byLine()) {
-        auto l = line.chomp;
+      foreach(line; f.byLine()) {
+          auto l = line.chomp.idup;
         string cmpLine = l;
         string cmpPref = prefix;
         if(useTerm) {
@@ -46,16 +48,16 @@ void lookCommand(string[] tokens)
             p = cmpPref.indexOf(term);
             if(p >= 0) cmpPref = cmpPref[0 .. p+1];
         }
-        if(dict) {
-            cmpLine = cmpLine.filter!(c => isAlphaNum(c)).idup;
-            cmpPref = cmpPref.filter!(c => isAlphaNum(c)).idup;
-        }
-        if(ignoreCase) {
-            cmpLine = toLower(cmpLine);
-            cmpPref = toLower(cmpPref);
-        }
-        if(cmpLine.startsWith(cmpPref))
-            writeln(l);
+          if(dict) {
+              cmpLine = cmpLine.filter!(c => isAlphaNum(c)).array.to!string;
+              cmpPref = cmpPref.filter!(c => isAlphaNum(c)).array.to!string;
+          }
+          if(ignoreCase) {
+              cmpLine = toLower(cmpLine);
+              cmpPref = toLower(cmpPref);
+          }
+          if(cmpLine.startsWith(cmpPref))
+              writeln(l);
     }
 }
 

--- a/src/ls.d
+++ b/src/ls.d
@@ -3,7 +3,7 @@ module ls;
 import std.stdio;
 import std.file : dirEntries, DirEntry, SpanMode;
 import std.algorithm : sort;
-import std.string : format;
+import std.string : format, startsWith;
 import std.datetime : unixTimeToStdTime, SysTime;
 import core.sys.posix.sys.stat : S_IFMT, S_IFDIR, S_IFLNK, S_IFCHR, S_IFBLK, S_IFIFO, S_IFSOCK,
     S_IRUSR, S_IWUSR, S_IXUSR, S_IRGRP, S_IWGRP, S_IXGRP, S_IROTH, S_IWOTH, S_IXOTH;
@@ -55,7 +55,7 @@ void lsCommand(string[] tokens)
         auto name = e.name;
         if(!all && name.startsWith(".")) continue;
         if(longFmt) {
-            auto st = e.stat;
+            auto st = e.statBuf;
             auto perms = permString(st.st_mode);
             auto size = st.st_size;
             writefln("%s %8d %s", perms, size, name);

--- a/src/lsblk.d
+++ b/src/lsblk.d
@@ -2,7 +2,7 @@ module lsblk;
 
 import std.stdio;
 import std.file : dirEntries, readText, exists, SpanMode;
-import std.string : strip;
+import std.string : strip, startsWith;
 import std.algorithm : sort;
 import std.conv : to;
 import df : humanSize;
@@ -12,7 +12,7 @@ void lsblkCommand(string[] tokens)
     bool bytes = false;
     bool all = false;
     size_t idx = 1;
-    while(idx < tokens.length && tokens[idx].startsWith("-")) {
+      while(idx < tokens.length && tokens[idx].startsWith("-")) {
         auto t = tokens[idx];
         if(t == "-b" || t == "--bytes") bytes = true;
         else if(t == "-a" || t == "--all") all = true;

--- a/src/lsof.d
+++ b/src/lsof.d
@@ -2,7 +2,7 @@ module lsof;
 
 import std.stdio;
 import std.file : dirEntries, readLink, readText, SpanMode;
-import std.string : strip;
+import std.string : strip, startsWith;
 import std.algorithm : sort;
 
 bool isNumeric(string s) {

--- a/src/md5sum.d
+++ b/src/md5sum.d
@@ -3,6 +3,7 @@ module md5sum;
 import std.stdio;
 import std.file : read;
 import std.digest.md;
+import std.format : format;
 
 string hexDigest(const(ubyte)[] data)
 {

--- a/src/objectsystem.d
+++ b/src/objectsystem.d
@@ -81,11 +81,11 @@ string introspect(string obj) {
 
 static Object parseSnapshot(string snap) {
     Object o;
-    foreach(part; snap.split(";")) {
-        if(part.length == 0) continue;
-        auto kv = part.split("=", 2);
-        auto key = kv[0];
-        auto val = kv.length > 1 ? kv[1] : "";
+      foreach(part; snap.split(";")) {
+          if(part.length == 0) continue;
+          auto kv = part.split("=");
+          auto key = kv[0];
+          auto val = kv.length > 1 ? kv[1] : "";
         if(key.startsWith("prop:")) {
             auto pkey = key[5 .. $];
             o.props[pkey] = val;


### PR DESCRIPTION
## Summary
- handle arithmetic switch default and background jobs
- add missing imports and proper string conversions across commands
- cleanup variable linkage and map handling in REPL and utilities

## Testing
- `ldc2 src/*.d -of=interpreter`


------
https://chatgpt.com/codex/tasks/task_e_689a182891948327813c3bab06e9e4af